### PR TITLE
fix: align GitHub token env handling

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -20,6 +20,6 @@ jobs:
 
       - name: Run review
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SURGE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SURGE_AI_API_KEY: ${{ secrets.SURGE_AI_API_KEY }}
         run: surge review --pr ${{ github.event.pull_request.number }}

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ jobs:
 
       - name: Run review
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SURGE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SURGE_AI_API_KEY: ${{ secrets.SURGE_AI_API_KEY }}
         run: surge review --pr ${{ github.event.pull_request.number }}
 ```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,7 +90,7 @@ func Load(configPath string) (*Config, error) {
 	v.AutomaticEnv()
 
 	// Bind specific env vars
-	_ = v.BindEnv("github.token", "SURGE_GITHUB_TOKEN")
+	_ = v.BindEnv("github.token", "SURGE_GITHUB_TOKEN", "GITHUB_TOKEN")
 	_ = v.BindEnv("github.owner", "SURGE_GITHUB_OWNER")
 	_ = v.BindEnv("github.repo", "SURGE_GITHUB_REPO")
 	_ = v.BindEnv("github.prNumber", "SURGE_PR_NUMBER")
@@ -130,6 +130,8 @@ func Load(configPath string) (*Config, error) {
 
 	// Override with env vars that were explicitly set
 	if token := os.Getenv("SURGE_GITHUB_TOKEN"); token != "" {
+		cfg.GitHub.Token = token
+	} else if token := os.Getenv("GITHUB_TOKEN"); token != "" {
 		cfg.GitHub.Token = token
 	}
 	if apiKey := os.Getenv("SURGE_AI_API_KEY"); apiKey != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -37,6 +37,15 @@ func TestLoad_EnvOverride(t *testing.T) {
 	assert.Equal(t, "test-api-key", cfg.AI.APIKey)
 }
 
+func TestLoad_GitHubTokenFallback(t *testing.T) {
+	os.Setenv("GITHUB_TOKEN", "fallback-token")
+	defer os.Unsetenv("GITHUB_TOKEN")
+
+	cfg, err := Load("")
+	assert.NoError(t, err)
+	assert.Equal(t, "fallback-token", cfg.GitHub.Token)
+}
+
 func TestLoad_ConfigFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "surge.yaml")


### PR DESCRIPTION
## Summary
- accept `GITHUB_TOKEN` as a fallback while keeping `SURGE_GITHUB_TOKEN` as the primary contract
- update the review workflow and README example to export `SURGE_GITHUB_TOKEN`
- add config coverage for the fallback path

Closes #9.

## Testing
- go test ./...