### PR TITLE
fix: send Claude system prompts correctly

### DIFF
--- a/internal/ai/claude.go
+++ b/internal/ai/claude.go
@@ -33,19 +33,18 @@ func (c *ClaudeClient) Complete(ctx context.Context, req *CompletionRequest) (*C
 	url := c.baseURL + "/messages"
 
 	// Build messages in Anthropic format
-	messages := make([]map[string]string, 0, len(req.Messages)+1)
-	if req.System != "" {
-		// Anthropic uses a system role
-		messages = append(messages, map[string]string{"role": "user", "content": req.System})
-	}
+	messages := make([]map[string]string, 0, len(req.Messages))
 	for _, m := range req.Messages {
 		messages = append(messages, map[string]string{"role": m.Role, "content": m.Content})
 	}
 
 	payload := map[string]interface{}{
-		"model":    c.model,
-		"messages":  messages,
+		"model":      c.model,
+		"messages":   messages,
 		"max_tokens": req.MaxTokens,
+	}
+	if req.System != "" {
+		payload["system"] = req.System
 	}
 
 	if req.Temperature > 0 {
@@ -65,7 +64,6 @@ func (c *ClaudeClient) Complete(ctx context.Context, req *CompletionRequest) (*C
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("x-api-key", c.apiKey)
 	httpReq.Header.Set("anthropic-version", "2023-06-01")
-	httpReq.Header.Set("anthropic-dangerous-direct-browser-access", "true")
 
 	resp, err := c.client.Do(httpReq)
 	if err != nil {

--- a/internal/ai/claude_test.go
+++ b/internal/ai/claude_test.go
@@ -1,0 +1,63 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClaudeClientCompleteUsesTopLevelSystemPrompt(t *testing.T) {
+	var requestBody map[string]interface{}
+	var dangerousHeader string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &requestBody))
+
+		dangerousHeader = r.Header.Get("anthropic-dangerous-direct-browser-access")
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err = w.Write([]byte(`{
+			"content": [{"type":"text","text":"{\"summary\":\"ok\",\"filesOverview\":[],\"findings\":[],\"vibeCheck\":{\"score\":8,\"verdict\":\"good\",\"flags\":[]},\"recommendations\":[],\"approve\":true}"}],
+			"usage": {"input_tokens": 10, "output_tokens": 20},
+			"stop_reason": "end_turn"
+		}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client := NewClaudeClient("test-key", "claude-test")
+	client.baseURL = server.URL
+	client.client = server.Client()
+
+	resp, err := client.Complete(context.Background(), &CompletionRequest{
+		Model:       "ignored-by-client",
+		System:      "system instructions",
+		Messages:    []Message{{Role: "user", Content: "review this"}},
+		MaxTokens:   1024,
+		Temperature: 0.3,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, resp.Content, `"summary":"ok"`)
+
+	assert.Equal(t, "system instructions", requestBody["system"])
+
+	messages, ok := requestBody["messages"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, messages, 1)
+
+	firstMessage, ok := messages[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "user", firstMessage["role"])
+	assert.Equal(t, "review this", firstMessage["content"])
+	assert.Empty(t, dangerousHeader)
+}


### PR DESCRIPTION
## Summary
- send Anthropic system instructions via the top-level `system` field
- keep user turns in `messages` only
- remove the browser-only Claude header and add request-shape coverage

Closes #6.

## Testing
- go test ./internal/ai ./...