### PR TITLE
Fix AI review idempotency by replacing prior Surge reviews

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -16,4 +16,8 @@ type PRClient interface {
 	PostComment(ctx context.Context, owner, repo string, prNumber int, body string) error
 	ListComments(ctx context.Context, owner, repo string, prNumber int) ([]*model.PRComment, error)
 	DeleteComment(ctx context.Context, owner, repo string, commentID int64) error
+	ListReviews(ctx context.Context, owner, repo string, prNumber int) ([]*model.PRReview, error)
+	DeleteReview(ctx context.Context, owner, repo string, prNumber int, reviewID int64) error
+	ListReviewComments(ctx context.Context, owner, repo string, prNumber int, reviewID int64) ([]*model.PRReviewComment, error)
+	DeleteReviewComment(ctx context.Context, owner, repo string, commentID int64) error
 }

--- a/internal/github/github_client.go
+++ b/internal/github/github_client.go
@@ -15,16 +15,16 @@ import (
 
 // GitHubClient implements PRClient for GitHub.
 type GitHubClient struct {
-	client  *http.Client
-	apiURL  string
+	client    *http.Client
+	apiURL    string
 	authToken string
 }
 
 // NewGitHubClient creates a new GitHub API client.
 func NewGitHubClient(token string) *GitHubClient {
 	return &GitHubClient{
-		client:  &http.Client{Timeout: 30 * time.Second},
-		apiURL:  "https://api.github.com",
+		client:    &http.Client{Timeout: 30 * time.Second},
+		apiURL:    "https://api.github.com",
 		authToken: token,
 	}
 }
@@ -85,11 +85,11 @@ func (c *GitHubClient) GetPR(ctx context.Context, owner, repo string, prNumber i
 	}
 
 	var prResp struct {
-		Number       int       `json:"number"`
-		Title        string    `json:"title"`
-		Body         string    `json:"body"`
-		State        string    `json:"state"`
-		User         struct {
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+		Body   string `json:"body"`
+		State  string `json:"state"`
+		User   struct {
 			Login string `json:"login"`
 		} `json:"user"`
 		Base struct {
@@ -302,9 +302,9 @@ func (c *GitHubClient) ListComments(ctx context.Context, owner, repo string, prN
 	}
 
 	var comments []struct {
-		ID        int64  `json:"id"`
-		Body      string `json:"body"`
-		User      struct {
+		ID   int64  `json:"id"`
+		Body string `json:"body"`
+		User struct {
 			Login string `json:"login"`
 			Type  string `json:"type"`
 		} `json:"user"`
@@ -340,6 +340,112 @@ func (c *GitHubClient) DeleteComment(ctx context.Context, owner, repo string, co
 
 	if status != http.StatusNoContent {
 		return fmt.Errorf("GitHub API error (%d)", status)
+	}
+
+	return nil
+}
+
+// ListReviews lists submitted reviews on a PR.
+func (c *GitHubClient) ListReviews(ctx context.Context, owner, repo string, prNumber int) ([]*model.PRReview, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/reviews", c.apiURL, owner, repo, prNumber)
+
+	body, status, err := c.doRequest(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("GitHub API error (%d): %s", status, string(body))
+	}
+
+	var reviews []struct {
+		ID   int64  `json:"id"`
+		Body string `json:"body"`
+		User struct {
+			Login string `json:"login"`
+			Type  string `json:"type"`
+		} `json:"user"`
+		CreatedAt string `json:"created_at"`
+	}
+
+	if err := json.Unmarshal(body, &reviews); err != nil {
+		return nil, fmt.Errorf("failed to parse reviews: %w", err)
+	}
+
+	result := make([]*model.PRReview, len(reviews))
+	for i, r := range reviews {
+		result[i] = &model.PRReview{
+			ID:        r.ID,
+			Body:      r.Body,
+			Author:    r.User.Login,
+			IsBot:     r.User.Type == "Bot",
+			CreatedAt: r.CreatedAt,
+		}
+	}
+
+	return result, nil
+}
+
+// DeleteReview deletes a review by ID.
+func (c *GitHubClient) DeleteReview(ctx context.Context, owner, repo string, prNumber int, reviewID int64) error {
+	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/reviews/%d", c.apiURL, owner, repo, prNumber, reviewID)
+
+	body, status, err := c.doRequest(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+
+	if status != http.StatusOK && status != http.StatusNoContent {
+		return fmt.Errorf("GitHub API error (%d): %s", status, string(body))
+	}
+
+	return nil
+}
+
+// ListReviewComments lists inline comments for a specific PR review.
+func (c *GitHubClient) ListReviewComments(ctx context.Context, owner, repo string, prNumber int, reviewID int64) ([]*model.PRReviewComment, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/reviews/%d/comments", c.apiURL, owner, repo, prNumber, reviewID)
+
+	body, status, err := c.doRequest(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("GitHub API error (%d): %s", status, string(body))
+	}
+
+	var comments []struct {
+		ID   int64  `json:"id"`
+		Body string `json:"body"`
+	}
+
+	if err := json.Unmarshal(body, &comments); err != nil {
+		return nil, fmt.Errorf("failed to parse review comments: %w", err)
+	}
+
+	result := make([]*model.PRReviewComment, len(comments))
+	for i, c := range comments {
+		result[i] = &model.PRReviewComment{
+			ID:   c.ID,
+			Body: c.Body,
+		}
+	}
+
+	return result, nil
+}
+
+// DeleteReviewComment deletes a PR inline review comment by ID.
+func (c *GitHubClient) DeleteReviewComment(ctx context.Context, owner, repo string, commentID int64) error {
+	url := fmt.Sprintf("%s/repos/%s/%s/pulls/comments/%d", c.apiURL, owner, repo, commentID)
+
+	body, status, err := c.doRequest(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return err
+	}
+
+	if status != http.StatusNoContent {
+		return fmt.Errorf("GitHub API error (%d): %s", status, string(body))
 	}
 
 	return nil

--- a/internal/model/review.go
+++ b/internal/model/review.go
@@ -2,30 +2,30 @@ package model
 
 // ReviewResult is the structured output from the AI code review.
 type ReviewResult struct {
-	Summary        string           `json:"summary"`
-	FilesOverview  []FileOverview   `json:"filesOverview"`
-	Findings       []Finding        `json:"findings"`
-	VibeCheck      VibeCheck        `json:"vibeCheck"`
-	Recommendations []string        `json:"recommendations"`
-	Approve        bool             `json:"approve"`
-	Stats          ReviewStats      `json:"stats,omitempty"`
+	Summary         string         `json:"summary"`
+	FilesOverview   []FileOverview `json:"filesOverview"`
+	Findings        []Finding      `json:"findings"`
+	VibeCheck       VibeCheck      `json:"vibeCheck"`
+	Recommendations []string       `json:"recommendations"`
+	Approve         bool           `json:"approve"`
+	Stats           ReviewStats    `json:"stats,omitempty"`
 }
 
 // FileOverview provides a summary of each changed file.
 type FileOverview struct {
-	Path  string `json:"path"`
+	Path    string `json:"path"`
 	Changes string `json:"changes"`
-	Risk  string `json:"risk"` // low, medium, high
+	Risk    string `json:"risk"` // low, medium, high
 }
 
 // Finding represents a single issue found in the code review.
 type Finding struct {
-	Severity Severity    `json:"severity"`
-	Category Category    `json:"category"`
-	File     string      `json:"file,omitempty"`
-	Line     int         `json:"line,omitempty"`
-	Title    string      `json:"title"`
-	Body     string      `json:"body"`
+	Severity Severity `json:"severity"`
+	Category Category `json:"category"`
+	File     string   `json:"file,omitempty"`
+	Line     int      `json:"line,omitempty"`
+	Title    string   `json:"title"`
+	Body     string   `json:"body"`
 }
 
 // Severity represents how severe a finding is.
@@ -33,10 +33,10 @@ type Severity string
 
 const (
 	SeverityCritical Severity = "critical"
-	SeverityHigh    Severity = "high"
-	SeverityMedium  Severity = "medium"
-	SeverityLow     Severity = "low"
-	SeverityInfo    Severity = "info"
+	SeverityHigh     Severity = "high"
+	SeverityMedium   Severity = "medium"
+	SeverityLow      Severity = "low"
+	SeverityInfo     Severity = "info"
 )
 
 // Category represents the type of issue found.
@@ -45,9 +45,9 @@ type Category string
 const (
 	CategorySecurity        Category = "security"
 	CategoryPerformance     Category = "performance"
-	CategoryLogic          Category = "logic"
+	CategoryLogic           Category = "logic"
 	CategoryMaintainability Category = "maintainability"
-	CategoryVibe           Category = "vibe"
+	CategoryVibe            Category = "vibe"
 )
 
 // VibeCheck represents the AI-generated vibe codability assessment.
@@ -81,9 +81,24 @@ type ReviewComment struct {
 
 // PRComment represents a comment on a PR.
 type PRComment struct {
-	ID      int64
-	Body    string
-	Author  string
-	IsBot   bool
+	ID        int64
+	Body      string
+	Author    string
+	IsBot     bool
 	CreatedAt string
+}
+
+// PRReview represents a pull request review.
+type PRReview struct {
+	ID        int64
+	Body      string
+	Author    string
+	IsBot     bool
+	CreatedAt string
+}
+
+// PRReviewComment represents an inline comment attached to a PR review.
+type PRReviewComment struct {
+	ID   int64
+	Body string
 }

--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -8,18 +8,27 @@ import (
 )
 
 // MarkdownOutput renders review results as GitHub-flavored markdown.
-type MarkdownOutput struct{}
+type MarkdownOutput struct {
+	commentMarker string
+}
 
 // NewMarkdownOutput creates a new markdown output renderer.
-func NewMarkdownOutput() *MarkdownOutput {
-	return &MarkdownOutput{}
+func NewMarkdownOutput(commentMarker string) *MarkdownOutput {
+	return &MarkdownOutput{
+		commentMarker: commentMarker,
+	}
 }
 
 // RenderSummary renders the full review summary as a markdown comment.
 func (m *MarkdownOutput) RenderSummary(result *model.ReviewResult) string {
 	var sb strings.Builder
 
-	sb.WriteString("<!-- SURGE_SUMMARY -->\n")
+	sb.WriteString("<!-- ")
+	sb.WriteString(m.commentMarker)
+	sb.WriteString(" -->\n")
+	sb.WriteString("<!-- ")
+	sb.WriteString(m.commentMarker)
+	sb.WriteString("_SUMMARY -->\n")
 	sb.WriteString("# AI Code Review by surge\n\n")
 
 	// Header stats

--- a/internal/review/orchestrator.go
+++ b/internal/review/orchestrator.go
@@ -16,15 +16,15 @@ import (
 
 // Orchestrator coordinates the full review pipeline.
 type Orchestrator struct {
-	aiClient  ai.AIClient
-	ghClient  github.PRClient
-	prompts   *PromptBuilder
-	parser    *OutputParser
-	vibe      *VibeDetector
-	mdOut     *output.MarkdownOutput
-	stdOut    *output.TerminalOutput
-	jsonOut   *output.JSONOutput
-	cfg       *config.Config
+	aiClient      ai.AIClient
+	ghClient      github.PRClient
+	prompts       *PromptBuilder
+	parser        *OutputParser
+	vibe          *VibeDetector
+	mdOut         *output.MarkdownOutput
+	stdOut        *output.TerminalOutput
+	jsonOut       *output.JSONOutput
+	cfg           *config.Config
 	commentMarker string
 }
 
@@ -36,7 +36,7 @@ func NewOrchestrator(aiClient ai.AIClient, ghClient github.PRClient, cfg *config
 		prompts:       NewPromptBuilder(),
 		parser:        NewOutputParser(),
 		vibe:          NewVibeDetector(),
-		mdOut:         output.NewMarkdownOutput(),
+		mdOut:         output.NewMarkdownOutput(cfg.CommentMarker),
 		stdOut:        output.NewTerminalOutput(),
 		jsonOut:       output.NewJSONOutput(),
 		cfg:           cfg,
@@ -78,8 +78,8 @@ func (o *Orchestrator) Review(ctx context.Context, owner, repo string, prNumber 
 	categories := o.filterCategories(systemPrompt)
 
 	aiReq := &ai.CompletionRequest{
-		Model:       o.cfg.AI.Model,
-		System:      categories,
+		Model:  o.cfg.AI.Model,
+		System: categories,
 		Messages: []ai.Message{
 			{Role: "user", Content: userPrompt},
 		},
@@ -239,14 +239,47 @@ func (o *Orchestrator) deleteOldComments(ctx context.Context, owner, repo string
 	}
 
 	for _, c := range comments {
-		if strings.Contains(c.Body, o.commentMarker) || strings.Contains(c.Body, "<!-- "+o.cfg.CommentMarker+"_") {
+		if o.isSurgeComment(c.Body) {
 			if err := o.ghClient.DeleteComment(ctx, owner, repo, c.ID); err != nil {
 				return err
 			}
 		}
 	}
 
+	reviews, err := o.ghClient.ListReviews(ctx, owner, repo, prNumber)
+	if err != nil {
+		return err
+	}
+
+	for _, r := range reviews {
+		if !o.isSurgeComment(r.Body) {
+			continue
+		}
+
+		reviewComments, err := o.ghClient.ListReviewComments(ctx, owner, repo, prNumber, r.ID)
+		if err != nil {
+			return err
+		}
+
+		for _, rc := range reviewComments {
+			if err := o.ghClient.DeleteReviewComment(ctx, owner, repo, rc.ID); err != nil {
+				return err
+			}
+		}
+
+		if err := o.ghClient.DeleteReview(ctx, owner, repo, prNumber, r.ID); err != nil {
+			return err
+		}
+	}
+
 	return nil
+}
+
+func (o *Orchestrator) isSurgeComment(body string) bool {
+	legacySummaryMarker := "<!-- SURGE_SUMMARY -->"
+	return strings.Contains(body, o.commentMarker) ||
+		strings.Contains(body, "<!-- "+o.cfg.CommentMarker+"_") ||
+		strings.Contains(body, legacySummaryMarker)
 }
 
 // findPositionInPatch finds the diff position for a given file line number.


### PR DESCRIPTION
## Summary
This fixes duplicate AI review spam on reruns by making cleanup operate on pull request reviews (and their inline review comments), not only issue comments.

## Changes
- Add GitHub client support for listing/deleting PR reviews
- Add GitHub client support for listing/deleting PR review inline comments
- Extend orchestrator cleanup to remove old Surge reviews + inline comments before posting a new one
- Make markdown summary marker config-driven and emit both base and summary markers
- Keep legacy marker matching for backwards compatibility

## Validation
- go test ./...