### PR TITLE
Add manual workflow to backfill release binaries

### DIFF
--- a/.github/workflows/release-backfill.yml
+++ b/.github/workflows/release-backfill.yml
@@ -1,0 +1,43 @@
+name: Release Backfill Assets
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to backfill (for example v0.3.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  backfill-assets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch tags
+        run: git fetch --force --tags
+
+      - name: Checkout release tag
+        run: git checkout "${{ inputs.tag }}"
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+
+      - name: Build release artifacts (no publish)
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean --skip=publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload artifacts to existing release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ inputs.tag }}" dist/* --clobber


### PR DESCRIPTION
## Summary
- add a workflow_dispatch workflow to backfill binaries for an existing release tag
- checkout the selected tag, build artifacts with GoReleaser without publish, then upload assets to that release

## Usage
- run workflow: Release Backfill Assets
- input tag: e.g. v0.3.0

## Why
When a release already exists without binaries, this provides a safe way to attach built artifacts retroactively.