### PR TITLE
Fix release backfill upload to include only archive assets

### DIFF
--- a/.github/workflows/release-backfill.yml
+++ b/.github/workflows/release-backfill.yml
@@ -40,4 +40,10 @@ jobs:
       - name: Upload artifacts to existing release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${{ inputs.tag }}" dist/* --clobber
+        run: |
+          mapfile -t assets < <(find dist -maxdepth 1 -type f \( -name "*.tar.gz" -o -name "*.zip" -o -name "checksums.txt" \) | sort)
+          if [ ${#assets[@]} -eq 0 ]; then
+            echo "No archive assets found in dist/"
+            exit 1
+          fi
+          gh release upload "${{ inputs.tag }}" "${assets[@]}" --clobber


### PR DESCRIPTION
## Summary
- fix Release Backfill Assets workflow upload step
- upload only archive/checksum files from dist instead of directories
- prevents gh release upload failure on GoReleaser output directories

## Root cause
 attempted to upload directories like .

## Testing
- validated command path and file filter logic in workflow