### PR TITLE
fix: make GitHub PR review reruns idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ All config values can be set via environment variables:
 
 ## GitHub Actions
 
+The GitHub token used for posting reviews must be able to write pull request reviews and dismiss prior bot reviews on reruns. On GitHub Actions, use a job-level permissions block that includes `pull-requests: write`.
+
 Add to your workflow:
 
 ```yaml
@@ -116,6 +118,9 @@ on:
 jobs:
   review:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -18,6 +18,7 @@ type PRClient interface {
 	DeleteComment(ctx context.Context, owner, repo string, commentID int64) error
 	ListReviews(ctx context.Context, owner, repo string, prNumber int) ([]*model.PRReview, error)
 	DeleteReview(ctx context.Context, owner, repo string, prNumber int, reviewID int64) error
+	DismissReview(ctx context.Context, owner, repo string, prNumber int, reviewID int64, message string) error
 	ListReviewComments(ctx context.Context, owner, repo string, prNumber int, reviewID int64) ([]*model.PRReviewComment, error)
 	DeleteReviewComment(ctx context.Context, owner, repo string, commentID int64) error
 	ListLabels(ctx context.Context, owner, repo string, prNumber int) ([]string, error)

--- a/internal/github/github_client.go
+++ b/internal/github/github_client.go
@@ -360,9 +360,10 @@ func (c *GitHubClient) ListReviews(ctx context.Context, owner, repo string, prNu
 	}
 
 	var reviews []struct {
-		ID   int64  `json:"id"`
-		Body string `json:"body"`
-		User struct {
+		ID    int64  `json:"id"`
+		Body  string `json:"body"`
+		State string `json:"state"`
+		User  struct {
 			Login string `json:"login"`
 			Type  string `json:"type"`
 		} `json:"user"`
@@ -378,6 +379,7 @@ func (c *GitHubClient) ListReviews(ctx context.Context, owner, repo string, prNu
 		result[i] = &model.PRReview{
 			ID:        r.ID,
 			Body:      r.Body,
+			State:     r.State,
 			Author:    r.User.Login,
 			IsBot:     r.User.Type == "Bot",
 			CreatedAt: r.CreatedAt,
@@ -397,6 +399,26 @@ func (c *GitHubClient) DeleteReview(ctx context.Context, owner, repo string, prN
 	}
 
 	if status != http.StatusOK && status != http.StatusNoContent {
+		return fmt.Errorf("GitHub API error (%d): %s", status, string(body))
+	}
+
+	return nil
+}
+
+// DismissReview dismisses a submitted review so reruns can supersede it.
+func (c *GitHubClient) DismissReview(ctx context.Context, owner, repo string, prNumber int, reviewID int64, message string) error {
+	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/reviews/%d/dismissals", c.apiURL, owner, repo, prNumber, reviewID)
+
+	payload := map[string]string{
+		"message": message,
+	}
+
+	body, status, err := c.doRequest(ctx, http.MethodPut, url, payload)
+	if err != nil {
+		return err
+	}
+
+	if status != http.StatusOK && status != http.StatusCreated {
 		return fmt.Errorf("GitHub API error (%d): %s", status, string(body))
 	}
 

--- a/internal/github/github_client_test.go
+++ b/internal/github/github_client_test.go
@@ -1,0 +1,46 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDismissReviewUsesDocumentedPayload(t *testing.T) {
+	var (
+		gotMethod string
+		gotPath   string
+		gotBody   map[string]string
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	client := NewGitHubClient("test-token")
+	client.apiURL = server.URL
+
+	err := client.DismissReview(context.Background(), "octo", "surge", 26, 99, "Superseded by a newer surge review run.")
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodPut, gotMethod)
+	assert.Equal(t, "/repos/octo/surge/pulls/26/reviews/99/dismissals", gotPath)
+	assert.Equal(t, map[string]string{
+		"message": "Superseded by a newer surge review run.",
+	}, gotBody)
+}

--- a/internal/model/review.go
+++ b/internal/model/review.go
@@ -92,6 +92,7 @@ type PRComment struct {
 type PRReview struct {
 	ID        int64
 	Body      string
+	State     string
 	Author    string
 	IsBot     bool
 	CreatedAt string

--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -12,6 +12,29 @@ type MarkdownOutput struct {
 	commentMarker string
 }
 
+const (
+	CommentScopeSummary = "SUMMARY"
+	CommentScopeInline  = "INLINE"
+)
+
+// ScopedCommentMarkers returns the scoped surge markers used across markdown output and cleanup.
+func ScopedCommentMarkers(marker string) []string {
+	return []string{
+		ScopedCommentMarker(marker, CommentScopeSummary),
+		ScopedCommentMarker(marker, CommentScopeInline),
+	}
+}
+
+// CommentMarker returns the base marker used to tag surge-authored comments.
+func CommentMarker(marker string) string {
+	return "<!-- " + marker + " -->"
+}
+
+// ScopedCommentMarker returns a scoped marker for a specific surge comment type.
+func ScopedCommentMarker(marker, scope string) string {
+	return "<!-- " + marker + "_" + scope + " -->"
+}
+
 // NewMarkdownOutput creates a new markdown output renderer.
 func NewMarkdownOutput(commentMarker string) *MarkdownOutput {
 	return &MarkdownOutput{
@@ -29,12 +52,10 @@ func (m *MarkdownOutput) RenderSummary(result *model.ReviewResult) string {
 		decision = "❌ Request Changes"
 	}
 
-	sb.WriteString("<!-- ")
-	sb.WriteString(m.commentMarker)
-	sb.WriteString(" -->\n")
-	sb.WriteString("<!-- ")
-	sb.WriteString(m.commentMarker)
-	sb.WriteString("_SUMMARY -->\n")
+	sb.WriteString(CommentMarker(m.commentMarker))
+	sb.WriteString("\n")
+	sb.WriteString(ScopedCommentMarker(m.commentMarker, CommentScopeSummary))
+	sb.WriteString("\n")
 	sb.WriteString("## ⚡ surge Review Summary\n\n")
 	sb.WriteString("| Decision | Findings | Files | Vibe |\n")
 	sb.WriteString("|---|---:|---:|---:|\n")

--- a/internal/review/orchestrator.go
+++ b/internal/review/orchestrator.go
@@ -2,6 +2,7 @@ package review
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -30,6 +31,17 @@ type Orchestrator struct {
 	commentMarker string
 }
 
+const reviewDismissalMessage = "Superseded by a newer surge review run."
+
+type cleanupStats struct {
+	deletedIssueComments  int
+	deletedReviewComments int
+	deletedReviews        int
+	dismissedReviews      int
+	skippedReviews        int
+	failedOperations      int
+}
+
 // NewOrchestrator creates a new review orchestrator.
 func NewOrchestrator(aiClient ai.AIClient, ghClient github.PRClient, cfg *config.Config) *Orchestrator {
 	return &Orchestrator{
@@ -42,7 +54,7 @@ func NewOrchestrator(aiClient ai.AIClient, ghClient github.PRClient, cfg *config
 		stdOut:        output.NewTerminalOutput(),
 		jsonOut:       output.NewJSONOutput(),
 		cfg:           cfg,
-		commentMarker: "<!-- " + cfg.CommentMarker + " -->",
+		commentMarker: output.CommentMarker(cfg.CommentMarker),
 	}
 }
 
@@ -168,9 +180,19 @@ func (o *Orchestrator) filterCategories(systemPrompt string) string {
 
 func (o *Orchestrator) postReview(ctx context.Context, owner, repo string, prNumber int, result *model.ReviewResult, files []model.FileChange) error {
 	// Delete old surge comments first (idempotency)
-	if err := o.deleteOldComments(ctx, owner, repo, prNumber); err != nil {
-		// Log but don't fail - the old comments will just pile up
-		fmt.Printf("Warning: failed to delete old comments: %v\n", err)
+	stats, err := o.deleteOldComments(ctx, owner, repo, prNumber)
+	if err != nil {
+		// Log but don't fail - reruns should still post the latest review.
+		fmt.Printf(
+			"Warning: surge cleanup completed with errors (deleted_issue_comments=%d deleted_review_comments=%d deleted_reviews=%d dismissed_reviews=%d skipped_reviews=%d failures=%d): %v\n",
+			stats.deletedIssueComments,
+			stats.deletedReviewComments,
+			stats.deletedReviews,
+			stats.dismissedReviews,
+			stats.skippedReviews,
+			stats.failedOperations,
+			err,
+		)
 	}
 
 	// Build inline comments
@@ -199,7 +221,7 @@ func (o *Orchestrator) postReview(ctx context.Context, owner, repo string, prNum
 		}
 
 		reviewInput := &model.ReviewInput{
-			Body:     "<!-- " + o.cfg.CommentMarker + "_INLINE -->",
+			Body:     output.ScopedCommentMarker(o.cfg.CommentMarker, output.CommentScopeInline),
 			Event:    event,
 			Comments: comments,
 		}
@@ -251,50 +273,90 @@ func (o *Orchestrator) buildInlineComments(result *model.ReviewResult, files []m
 	return comments
 }
 
-func (o *Orchestrator) deleteOldComments(ctx context.Context, owner, repo string, prNumber int) error {
+func (o *Orchestrator) deleteOldComments(ctx context.Context, owner, repo string, prNumber int) (cleanupStats, error) {
+	var stats cleanupStats
+	var cleanupErrs []error
+
 	comments, err := o.ghClient.ListComments(ctx, owner, repo, prNumber)
 	if err != nil {
-		return err
-	}
-
-	for _, c := range comments {
-		if o.isSurgeComment(c.Body) {
-			if err := o.ghClient.DeleteComment(ctx, owner, repo, c.ID); err != nil {
-				return err
+		stats.failedOperations++
+		cleanupErrs = append(cleanupErrs, fmt.Errorf("list issue comments: %w", err))
+	} else {
+		for _, c := range comments {
+			if o.isSurgeComment(c.Body) {
+				if err := o.ghClient.DeleteComment(ctx, owner, repo, c.ID); err != nil {
+					stats.failedOperations++
+					cleanupErrs = append(cleanupErrs, fmt.Errorf("delete issue comment %d: %w", c.ID, err))
+				} else {
+					stats.deletedIssueComments++
+				}
 			}
 		}
 	}
 
 	reviews, err := o.ghClient.ListReviews(ctx, owner, repo, prNumber)
 	if err != nil {
-		return err
-	}
+		stats.failedOperations++
+		cleanupErrs = append(cleanupErrs, fmt.Errorf("list reviews: %w", err))
+	} else {
+		for _, r := range reviews {
+			if !o.isSurgeComment(r.Body) {
+				continue
+			}
 
-	for _, r := range reviews {
-		if !o.isSurgeComment(r.Body) {
-			continue
-		}
+			reviewComments, err := o.ghClient.ListReviewComments(ctx, owner, repo, prNumber, r.ID)
+			if err != nil {
+				stats.failedOperations++
+				cleanupErrs = append(cleanupErrs, fmt.Errorf("list review comments for review %d: %w", r.ID, err))
+			} else {
+				for _, rc := range reviewComments {
+					if err := o.ghClient.DeleteReviewComment(ctx, owner, repo, rc.ID); err != nil {
+						stats.failedOperations++
+						cleanupErrs = append(cleanupErrs, fmt.Errorf("delete review comment %d: %w", rc.ID, err))
+					} else {
+						stats.deletedReviewComments++
+					}
+				}
+			}
 
-		reviewComments, err := o.ghClient.ListReviewComments(ctx, owner, repo, prNumber, r.ID)
-		if err != nil {
-			return err
-		}
-
-		for _, rc := range reviewComments {
-			if err := o.ghClient.DeleteReviewComment(ctx, owner, repo, rc.ID); err != nil {
-				return err
+			switch strings.ToUpper(strings.TrimSpace(r.State)) {
+			case "PENDING":
+				if err := o.ghClient.DeleteReview(ctx, owner, repo, prNumber, r.ID); err != nil {
+					stats.failedOperations++
+					cleanupErrs = append(cleanupErrs, fmt.Errorf("delete review %d: %w", r.ID, err))
+				} else {
+					stats.deletedReviews++
+				}
+			case "DISMISSED":
+				stats.skippedReviews++
+				continue
+			case "COMMENTED", "APPROVED", "CHANGES_REQUESTED":
+				if err := o.ghClient.DismissReview(ctx, owner, repo, prNumber, r.ID, reviewDismissalMessage); err != nil {
+					stats.failedOperations++
+					cleanupErrs = append(cleanupErrs, fmt.Errorf("dismiss review %d: %w", r.ID, err))
+				} else {
+					stats.dismissedReviews++
+				}
+			default:
+				stats.skippedReviews++
+				continue
 			}
 		}
 	}
 
-	return nil
+	return stats, errors.Join(cleanupErrs...)
 }
 
 func (o *Orchestrator) isSurgeComment(body string) bool {
-	legacySummaryMarker := "<!-- SURGE_SUMMARY -->"
-	return strings.Contains(body, o.commentMarker) ||
-		strings.Contains(body, "<!-- "+o.cfg.CommentMarker+"_") ||
-		strings.Contains(body, legacySummaryMarker)
+	if strings.Contains(body, o.commentMarker) {
+		return true
+	}
+	for _, marker := range output.ScopedCommentMarkers(o.cfg.CommentMarker) {
+		if strings.Contains(body, marker) {
+			return true
+		}
+	}
+	return strings.Contains(body, "<!-- SURGE_SUMMARY -->")
 }
 
 // findPositionInPatch finds the diff position for a given file line number.

--- a/internal/review/orchestrator_test.go
+++ b/internal/review/orchestrator_test.go
@@ -1,0 +1,366 @@
+package review
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/AtomicWasTaken/surge/internal/config"
+	"github.com/AtomicWasTaken/surge/internal/model"
+	"github.com/AtomicWasTaken/surge/internal/output"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubPRClient struct {
+	comments                []*model.PRComment
+	reviews                 []*model.PRReview
+	reviewComments          map[int64][]*model.PRReviewComment
+	deletedIssueCommentIDs  []int64
+	deletedReviewCommentIDs []int64
+	deletedReviewIDs        []int64
+	dismissedReviewIDs      []int64
+	dismissMessages         []string
+	postedCommentBodies     []string
+	postedReviews           []*model.ReviewInput
+	listReviewCommentsIDs   []int64
+	listCommentsErr         error
+	listReviewsErr          error
+	listReviewCommentsErrs  map[int64]error
+	deleteCommentErrs       map[int64]error
+	deleteReviewCommentErrs map[int64]error
+	deleteReviewErrs        map[int64]error
+	dismissReviewErrs       map[int64]error
+}
+
+func (s *stubPRClient) GetPR(ctx context.Context, owner, repo string, prNumber int) (*model.PR, error) {
+	return nil, nil
+}
+
+func (s *stubPRClient) GetDiff(ctx context.Context, owner, repo string, prNumber int) (string, error) {
+	return "", nil
+}
+
+func (s *stubPRClient) GetFiles(ctx context.Context, owner, repo string, prNumber int) ([]model.FileChange, error) {
+	return nil, nil
+}
+
+func (s *stubPRClient) GetFileContent(ctx context.Context, owner, repo, path, ref string) (string, error) {
+	return "", nil
+}
+
+func (s *stubPRClient) PostReview(ctx context.Context, owner, repo string, prNumber int, review *model.ReviewInput) error {
+	s.postedReviews = append(s.postedReviews, review)
+	return nil
+}
+
+func (s *stubPRClient) PostComment(ctx context.Context, owner, repo string, prNumber int, body string) error {
+	s.postedCommentBodies = append(s.postedCommentBodies, body)
+	return nil
+}
+
+func (s *stubPRClient) ListComments(ctx context.Context, owner, repo string, prNumber int) ([]*model.PRComment, error) {
+	if s.listCommentsErr != nil {
+		return nil, s.listCommentsErr
+	}
+	return s.comments, nil
+}
+
+func (s *stubPRClient) DeleteComment(ctx context.Context, owner, repo string, commentID int64) error {
+	if err := s.deleteCommentErrs[commentID]; err != nil {
+		return err
+	}
+	s.deletedIssueCommentIDs = append(s.deletedIssueCommentIDs, commentID)
+	return nil
+}
+
+func (s *stubPRClient) ListReviews(ctx context.Context, owner, repo string, prNumber int) ([]*model.PRReview, error) {
+	if s.listReviewsErr != nil {
+		return nil, s.listReviewsErr
+	}
+	return s.reviews, nil
+}
+
+func (s *stubPRClient) DeleteReview(ctx context.Context, owner, repo string, prNumber int, reviewID int64) error {
+	if err := s.deleteReviewErrs[reviewID]; err != nil {
+		return err
+	}
+	s.deletedReviewIDs = append(s.deletedReviewIDs, reviewID)
+	return nil
+}
+
+func (s *stubPRClient) DismissReview(ctx context.Context, owner, repo string, prNumber int, reviewID int64, message string) error {
+	if err := s.dismissReviewErrs[reviewID]; err != nil {
+		return err
+	}
+	s.dismissedReviewIDs = append(s.dismissedReviewIDs, reviewID)
+	s.dismissMessages = append(s.dismissMessages, message)
+	return nil
+}
+
+func (s *stubPRClient) ListReviewComments(ctx context.Context, owner, repo string, prNumber int, reviewID int64) ([]*model.PRReviewComment, error) {
+	if err := s.listReviewCommentsErrs[reviewID]; err != nil {
+		return nil, err
+	}
+	s.listReviewCommentsIDs = append(s.listReviewCommentsIDs, reviewID)
+	return s.reviewComments[reviewID], nil
+}
+
+func (s *stubPRClient) DeleteReviewComment(ctx context.Context, owner, repo string, commentID int64) error {
+	if err := s.deleteReviewCommentErrs[commentID]; err != nil {
+		return err
+	}
+	s.deletedReviewCommentIDs = append(s.deletedReviewCommentIDs, commentID)
+	return nil
+}
+
+func (s *stubPRClient) ListLabels(ctx context.Context, owner, repo string, prNumber int) ([]string, error) {
+	return nil, nil
+}
+
+func (s *stubPRClient) AddLabels(ctx context.Context, owner, repo string, prNumber int, labels []string) error {
+	return nil
+}
+
+func (s *stubPRClient) RemoveLabel(ctx context.Context, owner, repo string, prNumber int, label string) error {
+	return nil
+}
+
+func (s *stubPRClient) UpsertLabel(ctx context.Context, owner, repo, name, color, description string) error {
+	return nil
+}
+
+func TestDeleteOldCommentsCleansIssueCommentsAndSupersedesReviews(t *testing.T) {
+	client := &stubPRClient{
+		comments: []*model.PRComment{
+			{ID: 1, Body: "<!-- SURGE -->\nsummary"},
+			{ID: 2, Body: "human comment"},
+		},
+		reviews: []*model.PRReview{
+			{ID: 10, Body: "<!-- SURGE_INLINE -->", State: "COMMENTED"},
+			{ID: 11, Body: "<!-- SURGE_INLINE -->", State: "PENDING"},
+			{ID: 12, Body: "other bot", State: "APPROVED"},
+		},
+		reviewComments: map[int64][]*model.PRReviewComment{
+			10: {{ID: 101}, {ID: 102}},
+			11: {{ID: 111}},
+		},
+	}
+	cfg := &config.Config{CommentMarker: "SURGE"}
+	o := NewOrchestrator(nil, client, cfg)
+
+	stats, err := o.deleteOldComments(context.Background(), "o", "r", 1)
+	require.NoError(t, err)
+
+	assert.Equal(t, cleanupStats{
+		deletedIssueComments:  1,
+		deletedReviewComments: 3,
+		deletedReviews:        1,
+		dismissedReviews:      1,
+	}, stats)
+	assert.ElementsMatch(t, []int64{1}, client.deletedIssueCommentIDs)
+	assert.ElementsMatch(t, []int64{101, 102, 111}, client.deletedReviewCommentIDs)
+	assert.ElementsMatch(t, []int64{10}, client.dismissedReviewIDs)
+	assert.ElementsMatch(t, []int64{11}, client.deletedReviewIDs)
+	assert.ElementsMatch(t, []int64{10, 11}, client.listReviewCommentsIDs)
+	assert.Len(t, client.dismissMessages, 1)
+	assert.Equal(t, reviewDismissalMessage, client.dismissMessages[0])
+}
+
+func TestDeleteOldCommentsDismissesApprovedAndChangesRequestedReviews(t *testing.T) {
+	client := &stubPRClient{
+		reviews: []*model.PRReview{
+			{ID: 20, Body: "<!-- SURGE_INLINE -->", State: "APPROVED"},
+			{ID: 21, Body: "<!-- SURGE_INLINE -->", State: "CHANGES_REQUESTED"},
+		},
+		reviewComments: map[int64][]*model.PRReviewComment{
+			20: {},
+			21: {},
+		},
+	}
+	cfg := &config.Config{CommentMarker: "SURGE"}
+	o := NewOrchestrator(nil, client, cfg)
+
+	stats, err := o.deleteOldComments(context.Background(), "o", "r", 1)
+	require.NoError(t, err)
+
+	assert.Equal(t, cleanupStats{
+		dismissedReviews: 2,
+	}, stats)
+	assert.Empty(t, client.deletedReviewIDs)
+	assert.ElementsMatch(t, []int64{20, 21}, client.dismissedReviewIDs)
+	assert.ElementsMatch(t, []int64{20, 21}, client.listReviewCommentsIDs)
+}
+
+func TestDeleteOldCommentsSkipsUnknownAndEmptyStates(t *testing.T) {
+	client := &stubPRClient{
+		reviews: []*model.PRReview{
+			{ID: 30, Body: "<!-- SURGE_INLINE -->", State: ""},
+			{ID: 31, Body: "<!-- SURGE_INLINE -->", State: "COMMENTED"},
+			{ID: 32, Body: "<!-- SURGE_INLINE -->", State: "SOMETHING_NEW"},
+		},
+		reviewComments: map[int64][]*model.PRReviewComment{
+			30: {},
+			31: {},
+			32: {},
+		},
+	}
+	cfg := &config.Config{CommentMarker: "SURGE"}
+	o := NewOrchestrator(nil, client, cfg)
+
+	stats, err := o.deleteOldComments(context.Background(), "o", "r", 1)
+	require.NoError(t, err)
+
+	assert.Empty(t, client.deletedReviewIDs)
+	assert.ElementsMatch(t, []int64{31}, client.dismissedReviewIDs)
+	assert.ElementsMatch(t, []int64{30, 31, 32}, client.listReviewCommentsIDs)
+	assert.Equal(t, cleanupStats{
+		dismissedReviews: 1,
+		skippedReviews:   2,
+	}, stats)
+}
+
+func TestDeleteOldCommentsContinuesAfterCleanupFailures(t *testing.T) {
+	client := &stubPRClient{
+		comments: []*model.PRComment{
+			{ID: 1, Body: "<!-- SURGE -->"},
+			{ID: 2, Body: "<!-- SURGE -->"},
+		},
+		reviews: []*model.PRReview{
+			{ID: 10, Body: "<!-- SURGE_INLINE -->", State: "COMMENTED"},
+			{ID: 11, Body: "<!-- SURGE_INLINE -->", State: "PENDING"},
+		},
+		reviewComments: map[int64][]*model.PRReviewComment{
+			10: {{ID: 101}},
+			11: {{ID: 111}},
+		},
+		deleteCommentErrs: map[int64]error{
+			1: errors.New("no issue delete permission"),
+		},
+		deleteReviewCommentErrs: map[int64]error{
+			101: errors.New("no review comment delete permission"),
+		},
+		dismissReviewErrs: map[int64]error{
+			10: errors.New("dismiss denied"),
+		},
+		deleteReviewErrs: map[int64]error{
+			11: errors.New("delete denied"),
+		},
+	}
+	cfg := &config.Config{CommentMarker: "SURGE"}
+	o := NewOrchestrator(nil, client, cfg)
+
+	stats, err := o.deleteOldComments(context.Background(), "o", "r", 1)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "delete issue comment 1")
+	assert.ErrorContains(t, err, "delete review comment 101")
+	assert.ErrorContains(t, err, "dismiss review 10")
+	assert.ErrorContains(t, err, "delete review 11")
+	assert.ElementsMatch(t, []int64{2}, client.deletedIssueCommentIDs)
+	assert.ElementsMatch(t, []int64{111}, client.deletedReviewCommentIDs)
+	assert.ElementsMatch(t, []int64{10, 11}, client.listReviewCommentsIDs)
+	assert.Equal(t, cleanupStats{
+		deletedIssueComments:  1,
+		deletedReviewComments: 1,
+		failedOperations:      4,
+	}, stats)
+}
+
+func TestPostReviewLogsCleanupStatsOnPermissionFailures(t *testing.T) {
+	client := &stubPRClient{
+		comments: []*model.PRComment{
+			{ID: 1, Body: "<!-- SURGE -->"},
+		},
+		reviews: []*model.PRReview{
+			{ID: 10, Body: "<!-- SURGE_INLINE -->", State: "COMMENTED"},
+		},
+		reviewComments: map[int64][]*model.PRReviewComment{
+			10: {{ID: 101}},
+		},
+		deleteCommentErrs: map[int64]error{
+			1: errors.New("forbidden"),
+		},
+		deleteReviewCommentErrs: map[int64]error{
+			101: errors.New("forbidden"),
+		},
+		dismissReviewErrs: map[int64]error{
+			10: errors.New("forbidden"),
+		},
+	}
+	cfg := &config.Config{
+		CommentMarker:         "SURGE",
+		EnablePRLabels:        false,
+		DisableInlineComments: true,
+	}
+	o := NewOrchestrator(nil, client, cfg)
+
+	stdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	postErr := o.postReview(context.Background(), "o", "r", 1, &model.ReviewResult{}, nil)
+
+	require.NoError(t, w.Close())
+	os.Stdout = stdout
+	require.NoError(t, postErr)
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+
+	out := buf.String()
+	assert.Contains(t, out, "Warning: surge cleanup completed with errors")
+	assert.Contains(t, out, "deleted_issue_comments=0")
+	assert.Contains(t, out, "deleted_review_comments=0")
+	assert.Contains(t, out, "dismissed_reviews=0")
+	assert.Contains(t, out, "failures=3")
+}
+
+func TestPostReviewUsesDismissibleReviewEventForInlineComments(t *testing.T) {
+	client := &stubPRClient{reviewComments: map[int64][]*model.PRReviewComment{}}
+	cfg := &config.Config{
+		CommentMarker:         "SURGE",
+		EnablePRLabels:        false,
+		MaxInlineComments:     10,
+		DisableSummaryComment: false,
+	}
+	o := NewOrchestrator(nil, client, cfg)
+
+	result := &model.ReviewResult{
+		Approve: false,
+		Findings: []model.Finding{
+			{
+				Severity: model.SeverityHigh,
+				File:     "a.go",
+				Line:     2,
+				Title:    "Bug",
+				Body:     "Fix it",
+			},
+		},
+	}
+	files := []model.FileChange{
+		{Path: "a.go", Patch: "@@ -1,2 +1,2 @@\n line1\n+line2"},
+	}
+
+	err := o.postReview(context.Background(), "o", "r", 1, result, files)
+	require.NoError(t, err)
+	require.Len(t, client.postedCommentBodies, 1)
+	require.Len(t, client.postedReviews, 1)
+	assert.Equal(t, "COMMENT", client.postedReviews[0].Event)
+	assert.Equal(t, output.ScopedCommentMarker("SURGE", output.CommentScopeInline), client.postedReviews[0].Body)
+}
+
+func TestIsSurgeCommentRecognizesCurrentAndLegacyMarkers(t *testing.T) {
+	cfg := &config.Config{CommentMarker: "SURGE"}
+	o := NewOrchestrator(nil, &stubPRClient{}, cfg)
+
+	assert.True(t, o.isSurgeComment("<!-- SURGE -->"))
+	assert.True(t, o.isSurgeComment("<!-- SURGE_SUMMARY -->"))
+	assert.True(t, o.isSurgeComment(output.ScopedCommentMarker("SURGE", output.CommentScopeInline)))
+	assert.False(t, o.isSurgeComment("plain comment"))
+}


### PR DESCRIPTION
## Summary
- clean up prior surge issue comments and review comments before reposting
- dismiss submitted surge reviews and delete pending ones so reruns supersede earlier review state
- unify marker generation/detection and cover the rerun behavior with tests

## Testing
- go test ./...

Closes #1