### PR TITLE
chore: upgrade Go to 1.26.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.26.1'
           cache: true
 
       - name: Download dependencies
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.26.1'
 
       - name: Build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
         run: go test -race -coverprofile=coverage.out ./...
 
       - name: Run linter
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          version: v2.8.0
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.8.0
+          install-mode: goinstall
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/.github/workflows/release-backfill.yml
+++ b/.github/workflows/release-backfill.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.26.1"
 
       - name: Build release artifacts (no publish)
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.26.1'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.26.1'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.26.1'
 
       - name: Build surge
         run: go build -o /tmp/surge ./cmd/surge

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 **surge** is an AI-powered PR code review CLI tool written in Go. It analyzes pull request diffs and posts structured reviews with security findings, performance issues, logic bugs, code quality concerns, and a distinctive "vibe codability" check.
 
 - **Repo**: github.com/AtomicWasTaken/surge
-- **Go version**: 1.23
+- **Go version**: 1.26.1
 - **Main package**: `cmd/surge/main.go`
 
 ## Versioning

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/AtomicWasTaken/surge
 
-go 1.23
+go 1.26
+
+toolchain go1.26.1
 
 require (
 	github.com/charmbracelet/lipgloss v1.0.0

--- a/internal/ai/claude.go
+++ b/internal/ai/claude.go
@@ -76,7 +76,9 @@ func (c *ClaudeClient) Complete(ctx context.Context, req *CompletionRequest) (*C
 	if err != nil {
 		return nil, fmt.Errorf("claude request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/ai/litellm.go
+++ b/internal/ai/litellm.go
@@ -248,7 +248,9 @@ func (c *LiteLLMClient) doJSONPost(ctx context.Context, url string, payload map[
 	if err != nil {
 		return nil, 0, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/ai/litellm.go
+++ b/internal/ai/litellm.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -373,9 +374,9 @@ func parseResponsesSSE(body []byte) (string, int, int, string, error) {
 		if err := json.Unmarshal([]byte(data), &ev); err != nil {
 			return nil
 		}
-		if ev.Error.Message != "" {
-			return fmt.Errorf(ev.Error.Message)
-		}
+			if ev.Error.Message != "" {
+				return errors.New(ev.Error.Message)
+			}
 		switch ev.Type {
 		case "response.output_text.delta":
 			content.WriteString(ev.Delta)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -24,11 +24,11 @@ func TestLoad_Defaults(t *testing.T) {
 }
 
 func TestLoad_EnvOverride(t *testing.T) {
-	os.Setenv("SURGE_GITHUB_TOKEN", "test-token")
-	os.Setenv("SURGE_AI_API_KEY", "test-api-key")
+	assert.NoError(t, os.Setenv("SURGE_GITHUB_TOKEN", "test-token"))
+	assert.NoError(t, os.Setenv("SURGE_AI_API_KEY", "test-api-key"))
 	defer func() {
-		os.Unsetenv("SURGE_GITHUB_TOKEN")
-		os.Unsetenv("SURGE_AI_API_KEY")
+		assert.NoError(t, os.Unsetenv("SURGE_GITHUB_TOKEN"))
+		assert.NoError(t, os.Unsetenv("SURGE_AI_API_KEY"))
 	}()
 
 	cfg, err := Load("")
@@ -78,8 +78,10 @@ func TestConfig_Validate(t *testing.T) {
 }
 
 func TestExpandEnvVar(t *testing.T) {
-	os.Setenv("TEST_VAR", "test-value")
-	defer os.Unsetenv("TEST_VAR")
+	assert.NoError(t, os.Setenv("TEST_VAR", "test-value"))
+	defer func() {
+		assert.NoError(t, os.Unsetenv("TEST_VAR"))
+	}()
 
 	result := expandEnv("${TEST_VAR}")
 	assert.Equal(t, "test-value", result)

--- a/internal/github/github_client.go
+++ b/internal/github/github_client.go
@@ -56,7 +56,9 @@ func (c *GitHubClient) doRequest(ctx context.Context, method, url string, body i
 	if err != nil {
 		return nil, 0, fmt.Errorf("request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -147,7 +149,9 @@ func (c *GitHubClient) GetDiff(ctx context.Context, owner, repo string, prNumber
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch diff: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)

--- a/internal/review/prompts.go
+++ b/internal/review/prompts.go
@@ -145,7 +145,8 @@ func (pb *PromptBuilder) BuildUserPrompt(pr *PRContext, depth ContextDepth) stri
 	}
 	sb.WriteString("\n")
 
-	if depth == ContextDepthDiffOnly || depth == "" {
+	switch depth {
+	case "", ContextDepthDiffOnly:
 		sb.WriteString("Diff:\n")
 		for _, f := range pr.Files {
 			sb.WriteString("\n--- ")
@@ -154,7 +155,7 @@ func (pb *PromptBuilder) BuildUserPrompt(pr *PRContext, depth ContextDepth) stri
 			sb.WriteString(f.Patch)
 			sb.WriteString("\n")
 		}
-	} else if depth == ContextDepthRelevant || depth == ContextDepthFull {
+	case ContextDepthRelevant, ContextDepthFull:
 		for _, f := range pr.Files {
 			sb.WriteString("\n=== FILE: ")
 			sb.WriteString(f.Path)


### PR DESCRIPTION
## Summary
- upgrade the module and declared toolchain to Go 1.26.1
- update GitHub Actions workflows and docs to use Go 1.26.1
- fix a Go 1.26 vet failure in the LiteLLM client by replacing fmt.Errorf with errors.New for plain error strings

## Testing
- go test ./...
- go test -race ./...
- go build ./cmd/surge