### PR TITLE
refactor: clean up review orchestration and github client

### DIFF
--- a/internal/cli/review.go
+++ b/internal/cli/review.go
@@ -11,53 +11,14 @@ import (
 )
 
 func runReview(cmd *cobra.Command, args []string) error {
-	// Load config
-	cfg, err := config.Load(flagConfig)
+	cfg, err := loadReviewConfig(cmd)
 	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
+		return err
 	}
 
-	applyReviewFlagOverrides(cmd, cfg)
-
-	// Validate config
-	if err := cfg.Validate(); err != nil {
-		return fmt.Errorf("invalid config: %w", err)
-	}
-
-	// Apply explicit flag overrides
-	if cmd.Flags().Changed("verbose") {
-		cfg.Verbose = flagVerbose
-	}
-	_ = cmd // mark as used
-
-	// Apply --no-inline and --no-summary flags
-	if flagNoInline {
-		cfg.DisableInlineComments = true
-	}
-	if flagNoSummary {
-		cfg.DisableSummaryComment = true
-	}
-
-	// Detect owner/repo from git if not set
-	owner := cfg.GitHub.Owner
-	repo := cfg.GitHub.Repo
-	if owner == "" || repo == "" {
-		detectedOwner, detectedRepo, err := detectGitInfo()
-		if err != nil {
-			return fmt.Errorf("could not detect owner/repo: %w (use --owner and --repo flags, or set in config)", err)
-		}
-		if owner == "" {
-			owner = detectedOwner
-		}
-		if repo == "" {
-			repo = detectedRepo
-		}
-	}
-
-	// Get PR number
-	prNumber := cfg.GitHub.PRNumber
-	if prNumber <= 0 {
-		return fmt.Errorf("PR number is required (use --pr flag or set github.prNumber in config)")
+	owner, repo, prNumber, err := resolveReviewTarget(cfg)
+	if err != nil {
+		return err
 	}
 
 	if cfg.Verbose {
@@ -65,38 +26,23 @@ func runReview(cmd *cobra.Command, args []string) error {
 			owner, repo, prNumber, cfg.AI.Provider, cfg.AI.Model, cfg.AI.BaseURL, cfg.ContextDepth, flagDryRun)
 	}
 
-	// Check for required tokens
-	if cfg.GitHub.Token == "" {
-		return fmt.Errorf("GitHub token is required (set SURGE_GITHUB_TOKEN env var, or use --github-token flag)")
-	}
-	if cfg.AI.APIKey == "" && cfg.AI.Provider == "claude" {
-		return fmt.Errorf("AI API key is required (set SURGE_AI_API_KEY env var, or use --ai-api-key flag)")
+	if err := validateReviewCredentials(cfg); err != nil {
+		return err
 	}
 
-	// Create AI client
-	var aiClient ai.AIClient
-	switch cfg.AI.Provider {
-	case "litellm":
-		aiClient = ai.NewLiteLLMClient(cfg.AI.BaseURL, cfg.AI.APIKey, cfg.AI.Model)
-	case "claude":
-		aiClient = ai.NewClaudeClient(cfg.AI.APIKey, cfg.AI.Model)
-	default:
-		return fmt.Errorf("unknown AI provider: %s", cfg.AI.Provider)
+	aiClient, err := newAIClient(cfg)
+	if err != nil {
+		return err
 	}
 
-	// Create GitHub client
 	ghClient := github.NewGitHubClient(cfg.GitHub.Token)
-
-	// Create orchestrator
 	orch := review.NewOrchestrator(aiClient, ghClient, cfg)
 
-	// Run the review
 	result, err := orch.Review(cmd.Context(), owner, repo, prNumber, flagDryRun)
 	if err != nil {
 		return fmt.Errorf("review failed: %w", err)
 	}
 
-	// Print final status
 	if flagDryRun {
 		fmt.Println("\n[DRY RUN] No changes posted to the PR.")
 	} else {
@@ -109,6 +55,80 @@ func runReview(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func loadReviewConfig(cmd *cobra.Command) (*config.Config, error) {
+	cfg, err := config.Load(flagConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config: %w", err)
+	}
+
+	applyReviewFlagOverrides(cmd, cfg)
+	applyReviewBooleanOverrides(cmd, cfg)
+
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+
+	return cfg, nil
+}
+
+func applyReviewBooleanOverrides(cmd *cobra.Command, cfg *config.Config) {
+	if cmd.Flags().Changed("verbose") {
+		cfg.Verbose = flagVerbose
+	}
+	if flagNoInline {
+		cfg.DisableInlineComments = true
+	}
+	if flagNoSummary {
+		cfg.DisableSummaryComment = true
+	}
+}
+
+func resolveReviewTarget(cfg *config.Config) (owner, repo string, prNumber int, err error) {
+	owner = cfg.GitHub.Owner
+	repo = cfg.GitHub.Repo
+
+	if owner == "" || repo == "" {
+		detectedOwner, detectedRepo, detectErr := detectGitInfo()
+		if detectErr != nil {
+			return "", "", 0, fmt.Errorf("could not detect owner/repo: %w (use --owner and --repo flags, or set in config)", detectErr)
+		}
+		if owner == "" {
+			owner = detectedOwner
+		}
+		if repo == "" {
+			repo = detectedRepo
+		}
+	}
+
+	prNumber = cfg.GitHub.PRNumber
+	if prNumber <= 0 {
+		return "", "", 0, fmt.Errorf("PR number is required (use --pr flag or set github.prNumber in config)")
+	}
+
+	return owner, repo, prNumber, nil
+}
+
+func validateReviewCredentials(cfg *config.Config) error {
+	if cfg.GitHub.Token == "" {
+		return fmt.Errorf("GitHub token is required (set SURGE_GITHUB_TOKEN env var, or use --github-token flag)")
+	}
+	if cfg.AI.APIKey == "" && cfg.AI.Provider == "claude" {
+		return fmt.Errorf("AI API key is required (set SURGE_AI_API_KEY env var, or use --ai-api-key flag)")
+	}
+	return nil
+}
+
+func newAIClient(cfg *config.Config) (ai.AIClient, error) {
+	switch cfg.AI.Provider {
+	case "litellm":
+		return ai.NewLiteLLMClient(cfg.AI.BaseURL, cfg.AI.APIKey, cfg.AI.Model), nil
+	case "claude":
+		return ai.NewClaudeClient(cfg.AI.APIKey, cfg.AI.Model), nil
+	default:
+		return nil, fmt.Errorf("unknown AI provider: %s", cfg.AI.Provider)
+	}
 }
 
 func applyReviewFlagOverrides(cmd *cobra.Command, cfg *config.Config) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -247,7 +247,14 @@ func (c *Config) Validate() error {
 	if err := validateOneOf("output.format", c.Output.Format, validOutputFormat); err != nil {
 		return err
 	}
+	if !c.Categories.anyEnabled() {
+		return fmt.Errorf("at least one review category must be enabled")
+	}
 	return nil
+}
+
+func (c CategoriesConfig) anyEnabled() bool {
+	return c.Security || c.Performance || c.Logic || c.Maintainability || c.Vibe
 }
 
 func validateOneOf(field, value string, allowed []string) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,35 @@ import (
 	"github.com/spf13/viper"
 )
 
+const (
+	defaultAIProvider        = "litellm"
+	defaultAIModel           = "claude-sonnet-4-6"
+	defaultAIBaseURL         = "http://localhost:4000"
+	defaultContextDepth      = "diff-only"
+	defaultOutputFormat      = "terminal"
+	defaultOutputColorize    = true
+	defaultOutputShowStats   = false
+	defaultMaxTokens         = 8192
+	defaultTemperature       = 0.3
+	defaultMaxInlineComments = 20
+	defaultDisableInline     = false
+	defaultDisableSummary    = false
+	defaultCommentMarker     = "SURGE"
+	defaultEnablePRLabels    = true
+	defaultPRLabelPrefix     = "surge"
+)
+
+var (
+	validAIProviders  = []string{"litellm", "claude"}
+	validContextDepth = []string{"diff-only", "relevant", "full"}
+	validOutputFormat = []string{"terminal", "markdown", "json"}
+)
+
+type envBinding struct {
+	key string
+	env string
+}
+
 // Config represents the full surge configuration.
 type Config struct {
 	AI           AIConfig         `mapstructure:"ai"`
@@ -77,124 +106,120 @@ type GitHubConfig struct {
 func Load(configPath string) (*Config, error) {
 	v := viper.New()
 
-	// Set config file
-	if configPath != "" {
-		v.SetConfigFile(configPath)
-	} else {
-		v.SetConfigName("surge")
-		v.SetConfigType("yaml")
-		v.AddConfigPath(".")
-		v.AddConfigPath("./config")
-		v.AddConfigPath(filepath.Join(os.Getenv("HOME"), ".config", "surge"))
-		v.AddConfigPath("/etc/surge")
-	}
+	configureConfigSources(v, configPath)
 
-	// Environment variables
 	v.SetEnvPrefix("SURGE")
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()
+	bindEnvironment(v)
 
-	// Bind specific env vars
-	_ = v.BindEnv("github.token", "SURGE_GITHUB_TOKEN")
-	_ = v.BindEnv("github.owner", "SURGE_GITHUB_OWNER")
-	_ = v.BindEnv("github.repo", "SURGE_GITHUB_REPO")
-	_ = v.BindEnv("github.prNumber", "SURGE_PR_NUMBER")
-	_ = v.BindEnv("ai.provider", "SURGE_AI_PROVIDER")
-	_ = v.BindEnv("ai.model", "SURGE_AI_MODEL")
-	_ = v.BindEnv("ai.baseUrl", "SURGE_AI_BASE_URL")
-	_ = v.BindEnv("ai.apiKey", "SURGE_AI_API_KEY")
-	_ = v.BindEnv("contextDepth", "SURGE_CONTEXT_DEPTH")
-	_ = v.BindEnv("output.format", "SURGE_OUTPUT")
-	_ = v.BindEnv("output.showStats", "SURGE_SHOW_STATS")
-	_ = v.BindEnv("maxInlineComments", "SURGE_MAX_INLINE")
-	_ = v.BindEnv("maxTokens", "SURGE_MAX_TOKENS")
-	_ = v.BindEnv("temperature", "SURGE_TEMPERATURE")
-	_ = v.BindEnv("dryRun", "SURGE_DRY_RUN")
-	_ = v.BindEnv("verbose", "SURGE_VERBOSE")
-	_ = v.BindEnv("noInline", "SURGE_NO_INLINE")
-	_ = v.BindEnv("noSummary", "SURGE_NO_SUMMARY")
-	_ = v.BindEnv("enablePRLabels", "SURGE_ENABLE_PR_LABELS")
-	_ = v.BindEnv("prLabelPrefix", "SURGE_PR_LABEL_PREFIX")
-
-	// Read config file if it exists
 	if err := v.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
 			return nil, fmt.Errorf("failed to read config: %w", err)
 		}
 	}
 
-	// Apply defaults
 	applyDefaults(v)
 
-	// Unmarshal
 	var cfg Config
 	if err := v.Unmarshal(&cfg); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
-	// Expand env var references in config values
 	cfg.expandEnvVars()
-
-	// Override with env vars that were explicitly set
-	if token := os.Getenv("SURGE_GITHUB_TOKEN"); token != "" {
-		cfg.GitHub.Token = token
-	}
-	if apiKey := os.Getenv("SURGE_AI_API_KEY"); apiKey != "" {
-		cfg.AI.APIKey = apiKey
-	}
+	cfg.applyExplicitEnvOverrides()
 
 	return &cfg, nil
 }
 
+func configureConfigSources(v *viper.Viper, configPath string) {
+	if configPath != "" {
+		v.SetConfigFile(configPath)
+		return
+	}
+
+	v.SetConfigName("surge")
+	v.SetConfigType("yaml")
+	v.AddConfigPath(".")
+	v.AddConfigPath("./config")
+	v.AddConfigPath(filepath.Join(os.Getenv("HOME"), ".config", "surge"))
+	v.AddConfigPath("/etc/surge")
+}
+
+func bindEnvironment(v *viper.Viper) {
+	for _, binding := range []envBinding{
+		{key: "github.token", env: "SURGE_GITHUB_TOKEN"},
+		{key: "github.owner", env: "SURGE_GITHUB_OWNER"},
+		{key: "github.repo", env: "SURGE_GITHUB_REPO"},
+		{key: "github.prNumber", env: "SURGE_PR_NUMBER"},
+		{key: "ai.provider", env: "SURGE_AI_PROVIDER"},
+		{key: "ai.model", env: "SURGE_AI_MODEL"},
+		{key: "ai.baseUrl", env: "SURGE_AI_BASE_URL"},
+		{key: "ai.apiKey", env: "SURGE_AI_API_KEY"},
+		{key: "contextDepth", env: "SURGE_CONTEXT_DEPTH"},
+		{key: "output.format", env: "SURGE_OUTPUT"},
+		{key: "output.showStats", env: "SURGE_SHOW_STATS"},
+		{key: "maxInlineComments", env: "SURGE_MAX_INLINE"},
+		{key: "maxTokens", env: "SURGE_MAX_TOKENS"},
+		{key: "temperature", env: "SURGE_TEMPERATURE"},
+		{key: "dryRun", env: "SURGE_DRY_RUN"},
+		{key: "verbose", env: "SURGE_VERBOSE"},
+		{key: "noInline", env: "SURGE_NO_INLINE"},
+		{key: "noSummary", env: "SURGE_NO_SUMMARY"},
+		{key: "enablePRLabels", env: "SURGE_ENABLE_PR_LABELS"},
+		{key: "prLabelPrefix", env: "SURGE_PR_LABEL_PREFIX"},
+	} {
+		_ = v.BindEnv(binding.key, binding.env)
+	}
+}
+
 func applyDefaults(v *viper.Viper) {
-	// AI defaults
-	v.SetDefault("ai.provider", "litellm")
-	v.SetDefault("ai.model", "claude-sonnet-4-6")
-	v.SetDefault("ai.baseUrl", "http://localhost:4000")
+	defaults := map[string]interface{}{
+		"ai.provider":                defaultAIProvider,
+		"ai.model":                   defaultAIModel,
+		"ai.baseUrl":                 defaultAIBaseURL,
+		"contextDepth":               defaultContextDepth,
+		"output.format":              defaultOutputFormat,
+		"output.colorize":            defaultOutputColorize,
+		"output.showStats":           defaultOutputShowStats,
+		"categories.security":        true,
+		"categories.performance":     true,
+		"categories.logic":           true,
+		"categories.maintainability": true,
+		"categories.vibe":            true,
+		"maxTokens":                  defaultMaxTokens,
+		"temperature":                defaultTemperature,
+		"maxInlineComments":          defaultMaxInlineComments,
+		"disableInlineComments":      defaultDisableInline,
+		"disableSummaryComment":      defaultDisableSummary,
+		"commentMarker":              defaultCommentMarker,
+		"enablePRLabels":             defaultEnablePRLabels,
+		"prLabelPrefix":              defaultPRLabelPrefix,
+	}
 
-	// Context defaults
-	v.SetDefault("contextDepth", "diff-only")
-
-	// Output defaults
-	v.SetDefault("output.format", "terminal")
-	v.SetDefault("output.colorize", true)
-	v.SetDefault("output.showStats", false)
-
-	// Category defaults (all enabled)
-	v.SetDefault("categories.security", true)
-	v.SetDefault("categories.performance", true)
-	v.SetDefault("categories.logic", true)
-	v.SetDefault("categories.maintainability", true)
-	v.SetDefault("categories.vibe", true)
-
-	// Model settings
-	v.SetDefault("maxTokens", 8192)
-	v.SetDefault("temperature", 0.3)
-
-	// Inline comments
-	v.SetDefault("maxInlineComments", 20)
-	v.SetDefault("disableInlineComments", false)
-	v.SetDefault("disableSummaryComment", false)
-
-	// Comment marker
-	v.SetDefault("commentMarker", "SURGE")
-
-	// PR labels
-	v.SetDefault("enablePRLabels", true)
-	v.SetDefault("prLabelPrefix", "surge")
+	for key, value := range defaults {
+		v.SetDefault(key, value)
+	}
 }
 
 func (c *Config) expandEnvVars() {
-	// Expand ${VAR} patterns in string fields
 	c.AI.BaseURL = expandEnv(c.AI.BaseURL)
 	c.AI.APIKey = expandEnv(c.AI.APIKey)
+}
+
+func (c *Config) applyExplicitEnvOverrides() {
+	if token := os.Getenv("SURGE_GITHUB_TOKEN"); token != "" {
+		c.GitHub.Token = token
+	}
+	if apiKey := os.Getenv("SURGE_AI_API_KEY"); apiKey != "" {
+		c.AI.APIKey = apiKey
+	}
 }
 
 func expandEnv(s string) string {
 	if len(s) < 4 {
 		return s
 	}
-	// Simple ${VAR} expansion
 	if strings.HasPrefix(s, "${") && strings.HasSuffix(s, "}") {
 		varName := s[2 : len(s)-1]
 		if val := os.Getenv(varName); val != "" {
@@ -206,14 +231,29 @@ func expandEnv(s string) string {
 
 // Validate checks if the configuration is valid.
 func (c *Config) Validate() error {
-	if c.AI.Provider != "litellm" && c.AI.Provider != "claude" {
-		return fmt.Errorf("ai.provider must be 'litellm' or 'claude', got %q", c.AI.Provider)
+	if err := validateOneOf("ai.provider", c.AI.Provider, validAIProviders); err != nil {
+		return err
 	}
-	if c.ContextDepth != "diff-only" && c.ContextDepth != "relevant" && c.ContextDepth != "full" {
-		return fmt.Errorf("contextDepth must be 'diff-only', 'relevant', or 'full', got %q", c.ContextDepth)
+	if err := validateOneOf("contextDepth", c.ContextDepth, validContextDepth); err != nil {
+		return err
 	}
-	if c.Output.Format != "terminal" && c.Output.Format != "markdown" && c.Output.Format != "json" {
-		return fmt.Errorf("output.format must be 'terminal', 'markdown', or 'json', got %q", c.Output.Format)
+	if err := validateOneOf("output.format", c.Output.Format, validOutputFormat); err != nil {
+		return err
 	}
 	return nil
+}
+
+func validateOneOf(field, value string, allowed []string) error {
+	for _, candidate := range allowed {
+		if value == candidate {
+			return nil
+		}
+	}
+
+	quoted := make([]string, len(allowed))
+	for i, candidate := range allowed {
+		quoted[i] = fmt.Sprintf("%q", candidate)
+	}
+
+	return fmt.Errorf("%s must be one of %s, got %q", field, strings.Join(quoted, ", "), value)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -111,7 +112,9 @@ func Load(configPath string) (*Config, error) {
 	v.SetEnvPrefix("SURGE")
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()
-	bindEnvironment(v)
+	if err := bindEnvironment(v); err != nil {
+		return nil, fmt.Errorf("failed to bind environment variables: %w", err)
+	}
 
 	if err := v.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
@@ -146,7 +149,8 @@ func configureConfigSources(v *viper.Viper, configPath string) {
 	v.AddConfigPath("/etc/surge")
 }
 
-func bindEnvironment(v *viper.Viper) {
+func bindEnvironment(v *viper.Viper) error {
+	var errs []error
 	for _, binding := range []envBinding{
 		{key: "github.token", env: "SURGE_GITHUB_TOKEN"},
 		{key: "github.owner", env: "SURGE_GITHUB_OWNER"},
@@ -169,8 +173,11 @@ func bindEnvironment(v *viper.Viper) {
 		{key: "enablePRLabels", env: "SURGE_ENABLE_PR_LABELS"},
 		{key: "prLabelPrefix", env: "SURGE_PR_LABEL_PREFIX"},
 	} {
-		_ = v.BindEnv(binding.key, binding.env)
+		if err := v.BindEnv(binding.key, binding.env); err != nil {
+			errs = append(errs, fmt.Errorf("%s -> %s: %w", binding.key, binding.env, err))
+		}
 	}
+	return errors.Join(errs...)
 }
 
 func applyDefaults(v *viper.Viper) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -59,9 +59,12 @@ maxInlineComments: 10
 
 func TestConfig_Validate(t *testing.T) {
 	cfg := &Config{
-		AI:          AIConfig{Provider: "litellm"},
+		AI:           AIConfig{Provider: "litellm"},
 		ContextDepth: "diff-only",
-		Output:      OutputConfig{Format: "terminal"},
+		Output:       OutputConfig{Format: "terminal"},
+		Categories: CategoriesConfig{
+			Security: true,
+		},
 	}
 	assert.NoError(t, cfg.Validate())
 
@@ -75,6 +78,10 @@ func TestConfig_Validate(t *testing.T) {
 	cfg.ContextDepth = "diff-only"
 	cfg.Output.Format = "invalid"
 	assert.Error(t, cfg.Validate())
+
+	cfg.Output.Format = "terminal"
+	cfg.Categories = CategoriesConfig{}
+	assert.EqualError(t, cfg.Validate(), "at least one review category must be enabled")
 }
 
 func TestExpandEnvVar(t *testing.T) {

--- a/internal/github/github_client.go
+++ b/internal/github/github_client.go
@@ -14,6 +14,12 @@ import (
 	"github.com/AtomicWasTaken/surge/internal/model"
 )
 
+const (
+	githubJSONAcceptHeader = "application/vnd.github.v3+json"
+	githubDiffAcceptHeader = "application/vnd.github.v3.diff"
+	githubUserAgent        = "surge-ai-review/1.0"
+)
+
 // GitHubClient implements PRClient for GitHub.
 type GitHubClient struct {
 	client    *http.Client
@@ -30,7 +36,11 @@ func NewGitHubClient(token string) *GitHubClient {
 	}
 }
 
-func (c *GitHubClient) doRequest(ctx context.Context, method, url string, body interface{}) ([]byte, int, error) {
+func (c *GitHubClient) apiURLf(format string, args ...interface{}) string {
+	return fmt.Sprintf(c.apiURL+format, args...)
+}
+
+func (c *GitHubClient) doRequest(ctx context.Context, method, requestURL, acceptHeader string, body interface{}) ([]byte, int, error) {
 	var bodyReader io.Reader
 	if body != nil {
 		data, err := json.Marshal(body)
@@ -40,14 +50,14 @@ func (c *GitHubClient) doRequest(ctx context.Context, method, url string, body i
 		bodyReader = bytes.NewReader(data)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+	req, err := http.NewRequestWithContext(ctx, method, requestURL, bodyReader)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to create request: %w", err)
 	}
 
-	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("Accept", acceptHeader)
 	req.Header.Set("Authorization", "token "+c.authToken)
-	req.Header.Set("User-Agent", "surge-ai-review/1.0")
+	req.Header.Set("User-Agent", githubUserAgent)
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
@@ -68,11 +78,35 @@ func (c *GitHubClient) doRequest(ctx context.Context, method, url string, body i
 	return respBody, resp.StatusCode, nil
 }
 
+func (c *GitHubClient) doJSONRequest(ctx context.Context, method, requestURL string, body interface{}) ([]byte, int, error) {
+	return c.doRequest(ctx, method, requestURL, githubJSONAcceptHeader, body)
+}
+
+func parseJSONResponse[T any](body []byte, target *T, operation string) error {
+	if err := json.Unmarshal(body, target); err != nil {
+		return fmt.Errorf("failed to parse %s: %w", operation, err)
+	}
+	return nil
+}
+
+func expectStatus(status int, allowed ...int) bool {
+	for _, candidate := range allowed {
+		if status == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func githubAPIError(status int, body []byte) error {
+	return fmt.Errorf("GitHub API error (%d): %s", status, string(body))
+}
+
 // GetPR fetches the metadata for a pull request.
 func (c *GitHubClient) GetPR(ctx context.Context, owner, repo string, prNumber int) (*model.PR, error) {
-	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d", c.apiURL, owner, repo, prNumber)
+	requestURL := c.apiURLf("/repos/%s/%s/pulls/%d", owner, repo, prNumber)
 
-	body, status, err := c.doRequest(ctx, http.MethodGet, url, nil)
+	body, status, err := c.doJSONRequest(ctx, http.MethodGet, requestURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -111,8 +145,8 @@ func (c *GitHubClient) GetPR(ctx context.Context, owner, repo string, prNumber i
 		UpdatedAt    time.Time `json:"updated_at"`
 	}
 
-	if err := json.Unmarshal(body, &prResp); err != nil {
-		return nil, fmt.Errorf("failed to parse PR response: %w", err)
+	if err := parseJSONResponse(body, &prResp, "PR response"); err != nil {
+		return nil, err
 	}
 
 	return &model.PR{
@@ -136,47 +170,30 @@ func (c *GitHubClient) GetPR(ctx context.Context, owner, repo string, prNumber i
 
 // GetDiff fetches the unified diff for a PR.
 func (c *GitHubClient) GetDiff(ctx context.Context, owner, repo string, prNumber int) (string, error) {
-	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d", c.apiURL, owner, repo, prNumber)
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	requestURL := c.apiURLf("/repos/%s/%s/pulls/%d", owner, repo, prNumber)
+	body, status, err := c.doRequest(ctx, http.MethodGet, requestURL, githubDiffAcceptHeader, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to create request: %w", err)
-	}
-	req.Header.Set("Accept", "application/vnd.github.v3.diff")
-	req.Header.Set("Authorization", "token "+c.authToken)
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to fetch diff: %w", err)
-	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("GitHub API error (%d): %s", resp.StatusCode, string(respBody))
+		return "", err
 	}
 
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("failed to read diff: %w", err)
+	if status != http.StatusOK {
+		return "", githubAPIError(status, body)
 	}
 
-	return string(data), nil
+	return string(body), nil
 }
 
 // GetFiles fetches the list of changed files with their patches.
 func (c *GitHubClient) GetFiles(ctx context.Context, owner, repo string, prNumber int) ([]model.FileChange, error) {
-	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/files", c.apiURL, owner, repo, prNumber)
+	requestURL := c.apiURLf("/repos/%s/%s/pulls/%d/files", owner, repo, prNumber)
 
-	body, status, err := c.doRequest(ctx, http.MethodGet, url, nil)
+	body, status, err := c.doJSONRequest(ctx, http.MethodGet, requestURL, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	if status != http.StatusOK {
-		return nil, fmt.Errorf("GitHub API error (%d): %s", status, string(body))
+		return nil, githubAPIError(status, body)
 	}
 
 	var files []struct {
@@ -188,8 +205,8 @@ func (c *GitHubClient) GetFiles(ctx context.Context, owner, repo string, prNumbe
 		Patch     string `json:"patch"`
 	}
 
-	if err := json.Unmarshal(body, &files); err != nil {
-		return nil, fmt.Errorf("failed to parse files response: %w", err)
+	if err := parseJSONResponse(body, &files, "files response"); err != nil {
+		return nil, err
 	}
 
 	result := make([]model.FileChange, len(files))
@@ -208,9 +225,9 @@ func (c *GitHubClient) GetFiles(ctx context.Context, owner, repo string, prNumbe
 
 // GetFileContent fetches the content of a specific file at a given ref.
 func (c *GitHubClient) GetFileContent(ctx context.Context, owner, repo, path, ref string) (string, error) {
-	url := fmt.Sprintf("%s/repos/%s/%s/contents/%s?ref=%s", c.apiURL, owner, repo, path, ref)
+	requestURL := c.apiURLf("/repos/%s/%s/contents/%s?ref=%s", owner, repo, path, ref)
 
-	body, status, err := c.doRequest(ctx, http.MethodGet, url, nil)
+	body, status, err := c.doJSONRequest(ctx, http.MethodGet, requestURL, nil)
 	if err != nil {
 		return "", err
 	}
@@ -227,8 +244,8 @@ func (c *GitHubClient) GetFileContent(ctx context.Context, owner, repo, path, re
 		Encoding string `json:"encoding"`
 	}
 
-	if err := json.Unmarshal(body, &fileResp); err != nil {
-		return "", fmt.Errorf("failed to parse file response: %w", err)
+	if err := parseJSONResponse(body, &fileResp, "file response"); err != nil {
+		return "", err
 	}
 
 	decoded, err := base64.StdEncoding.DecodeString(fileResp.Content)
@@ -241,7 +258,7 @@ func (c *GitHubClient) GetFileContent(ctx context.Context, owner, repo, path, re
 
 // PostReview posts a review with inline comments and a summary.
 func (c *GitHubClient) PostReview(ctx context.Context, owner, repo string, prNumber int, review *model.ReviewInput) error {
-	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/reviews", c.apiURL, owner, repo, prNumber)
+	requestURL := c.apiURLf("/repos/%s/%s/pulls/%d/reviews", owner, repo, prNumber)
 
 	payload := map[string]interface{}{
 		"event": review.Event,
@@ -260,7 +277,7 @@ func (c *GitHubClient) PostReview(ctx context.Context, owner, repo string, prNum
 		payload["comments"] = comments
 	}
 
-	body, status, err := c.doRequest(ctx, http.MethodPost, url, payload)
+	body, status, err := c.doJSONRequest(ctx, http.MethodPost, requestURL, payload)
 	if err != nil {
 		return err
 	}
@@ -268,8 +285,8 @@ func (c *GitHubClient) PostReview(ctx context.Context, owner, repo string, prNum
 	if status == http.StatusUnprocessableEntity {
 		return fmt.Errorf("review position is stale (lines may have moved since the diff was generated)")
 	}
-	if status != http.StatusOK && status != http.StatusCreated {
-		return fmt.Errorf("GitHub API error (%d): %s", status, string(body))
+	if !expectStatus(status, http.StatusOK, http.StatusCreated) {
+		return githubAPIError(status, body)
 	}
 
 	return nil
@@ -277,17 +294,17 @@ func (c *GitHubClient) PostReview(ctx context.Context, owner, repo string, prNum
 
 // PostComment posts a general comment on the PR.
 func (c *GitHubClient) PostComment(ctx context.Context, owner, repo string, prNumber int, body string) error {
-	url := fmt.Sprintf("%s/repos/%s/%s/issues/%d/comments", c.apiURL, owner, repo, prNumber)
+	requestURL := c.apiURLf("/repos/%s/%s/issues/%d/comments", owner, repo, prNumber)
 
 	payload := map[string]string{"body": body}
 
-	respBody, status, err := c.doRequest(ctx, http.MethodPost, url, payload)
+	respBody, status, err := c.doJSONRequest(ctx, http.MethodPost, requestURL, payload)
 	if err != nil {
 		return err
 	}
 
 	if status != http.StatusCreated {
-		return fmt.Errorf("GitHub API error (%d): %s", status, string(respBody))
+		return githubAPIError(status, respBody)
 	}
 
 	return nil
@@ -295,15 +312,15 @@ func (c *GitHubClient) PostComment(ctx context.Context, owner, repo string, prNu
 
 // ListComments lists comments on a PR.
 func (c *GitHubClient) ListComments(ctx context.Context, owner, repo string, prNumber int) ([]*model.PRComment, error) {
-	url := fmt.Sprintf("%s/repos/%s/%s/issues/%d/comments", c.apiURL, owner, repo, prNumber)
+	requestURL := c.apiURLf("/repos/%s/%s/issues/%d/comments", owner, repo, prNumber)
 
-	body, status, err := c.doRequest(ctx, http.MethodGet, url, nil)
+	body, status, err := c.doJSONRequest(ctx, http.MethodGet, requestURL, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	if status != http.StatusOK {
-		return nil, fmt.Errorf("GitHub API error (%d): %s", status, string(body))
+		return nil, githubAPIError(status, body)
 	}
 
 	var comments []struct {
@@ -316,8 +333,8 @@ func (c *GitHubClient) ListComments(ctx context.Context, owner, repo string, prN
 		CreatedAt string `json:"created_at"`
 	}
 
-	if err := json.Unmarshal(body, &comments); err != nil {
-		return nil, fmt.Errorf("failed to parse comments: %w", err)
+	if err := parseJSONResponse(body, &comments, "comments"); err != nil {
+		return nil, err
 	}
 
 	result := make([]*model.PRComment, len(comments))
@@ -336,9 +353,9 @@ func (c *GitHubClient) ListComments(ctx context.Context, owner, repo string, prN
 
 // DeleteComment deletes a comment by ID.
 func (c *GitHubClient) DeleteComment(ctx context.Context, owner, repo string, commentID int64) error {
-	url := fmt.Sprintf("%s/repos/%s/%s/issues/comments/%d", c.apiURL, owner, repo, commentID)
+	requestURL := c.apiURLf("/repos/%s/%s/issues/comments/%d", owner, repo, commentID)
 
-	_, status, err := c.doRequest(ctx, http.MethodDelete, url, nil)
+	_, status, err := c.doJSONRequest(ctx, http.MethodDelete, requestURL, nil)
 	if err != nil {
 		return err
 	}
@@ -352,15 +369,15 @@ func (c *GitHubClient) DeleteComment(ctx context.Context, owner, repo string, co
 
 // ListReviews lists submitted reviews on a PR.
 func (c *GitHubClient) ListReviews(ctx context.Context, owner, repo string, prNumber int) ([]*model.PRReview, error) {
-	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/reviews", c.apiURL, owner, repo, prNumber)
+	requestURL := c.apiURLf("/repos/%s/%s/pulls/%d/reviews", owner, repo, prNumber)
 
-	body, status, err := c.doRequest(ctx, http.MethodGet, url, nil)
+	body, status, err := c.doJSONRequest(ctx, http.MethodGet, requestURL, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	if status != http.StatusOK {
-		return nil, fmt.Errorf("GitHub API error (%d): %s", status, string(body))
+		return nil, githubAPIError(status, body)
 	}
 
 	var reviews []struct {
@@ -374,8 +391,8 @@ func (c *GitHubClient) ListReviews(ctx context.Context, owner, repo string, prNu
 		CreatedAt string `json:"created_at"`
 	}
 
-	if err := json.Unmarshal(body, &reviews); err != nil {
-		return nil, fmt.Errorf("failed to parse reviews: %w", err)
+	if err := parseJSONResponse(body, &reviews, "reviews"); err != nil {
+		return nil, err
 	}
 
 	result := make([]*model.PRReview, len(reviews))
@@ -395,15 +412,15 @@ func (c *GitHubClient) ListReviews(ctx context.Context, owner, repo string, prNu
 
 // DeleteReview deletes a review by ID.
 func (c *GitHubClient) DeleteReview(ctx context.Context, owner, repo string, prNumber int, reviewID int64) error {
-	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/reviews/%d", c.apiURL, owner, repo, prNumber, reviewID)
+	requestURL := c.apiURLf("/repos/%s/%s/pulls/%d/reviews/%d", owner, repo, prNumber, reviewID)
 
-	body, status, err := c.doRequest(ctx, http.MethodDelete, url, nil)
+	body, status, err := c.doJSONRequest(ctx, http.MethodDelete, requestURL, nil)
 	if err != nil {
 		return err
 	}
 
-	if status != http.StatusOK && status != http.StatusNoContent {
-		return fmt.Errorf("GitHub API error (%d): %s", status, string(body))
+	if !expectStatus(status, http.StatusOK, http.StatusNoContent) {
+		return githubAPIError(status, body)
 	}
 
 	return nil
@@ -411,19 +428,19 @@ func (c *GitHubClient) DeleteReview(ctx context.Context, owner, repo string, prN
 
 // DismissReview dismisses a submitted review so reruns can supersede it.
 func (c *GitHubClient) DismissReview(ctx context.Context, owner, repo string, prNumber int, reviewID int64, message string) error {
-	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/reviews/%d/dismissals", c.apiURL, owner, repo, prNumber, reviewID)
+	requestURL := c.apiURLf("/repos/%s/%s/pulls/%d/reviews/%d/dismissals", owner, repo, prNumber, reviewID)
 
 	payload := map[string]string{
 		"message": message,
 	}
 
-	body, status, err := c.doRequest(ctx, http.MethodPut, url, payload)
+	body, status, err := c.doJSONRequest(ctx, http.MethodPut, requestURL, payload)
 	if err != nil {
 		return err
 	}
 
-	if status != http.StatusOK && status != http.StatusCreated {
-		return fmt.Errorf("GitHub API error (%d): %s", status, string(body))
+	if !expectStatus(status, http.StatusOK, http.StatusCreated) {
+		return githubAPIError(status, body)
 	}
 
 	return nil
@@ -431,15 +448,15 @@ func (c *GitHubClient) DismissReview(ctx context.Context, owner, repo string, pr
 
 // ListReviewComments lists inline comments for a specific PR review.
 func (c *GitHubClient) ListReviewComments(ctx context.Context, owner, repo string, prNumber int, reviewID int64) ([]*model.PRReviewComment, error) {
-	url := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/reviews/%d/comments", c.apiURL, owner, repo, prNumber, reviewID)
+	requestURL := c.apiURLf("/repos/%s/%s/pulls/%d/reviews/%d/comments", owner, repo, prNumber, reviewID)
 
-	body, status, err := c.doRequest(ctx, http.MethodGet, url, nil)
+	body, status, err := c.doJSONRequest(ctx, http.MethodGet, requestURL, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	if status != http.StatusOK {
-		return nil, fmt.Errorf("GitHub API error (%d): %s", status, string(body))
+		return nil, githubAPIError(status, body)
 	}
 
 	var comments []struct {
@@ -447,8 +464,8 @@ func (c *GitHubClient) ListReviewComments(ctx context.Context, owner, repo strin
 		Body string `json:"body"`
 	}
 
-	if err := json.Unmarshal(body, &comments); err != nil {
-		return nil, fmt.Errorf("failed to parse review comments: %w", err)
+	if err := parseJSONResponse(body, &comments, "review comments"); err != nil {
+		return nil, err
 	}
 
 	result := make([]*model.PRReviewComment, len(comments))
@@ -464,15 +481,15 @@ func (c *GitHubClient) ListReviewComments(ctx context.Context, owner, repo strin
 
 // DeleteReviewComment deletes a PR inline review comment by ID.
 func (c *GitHubClient) DeleteReviewComment(ctx context.Context, owner, repo string, commentID int64) error {
-	url := fmt.Sprintf("%s/repos/%s/%s/pulls/comments/%d", c.apiURL, owner, repo, commentID)
+	requestURL := c.apiURLf("/repos/%s/%s/pulls/comments/%d", owner, repo, commentID)
 
-	body, status, err := c.doRequest(ctx, http.MethodDelete, url, nil)
+	body, status, err := c.doJSONRequest(ctx, http.MethodDelete, requestURL, nil)
 	if err != nil {
 		return err
 	}
 
 	if status != http.StatusNoContent {
-		return fmt.Errorf("GitHub API error (%d): %s", status, string(body))
+		return githubAPIError(status, body)
 	}
 
 	return nil
@@ -480,22 +497,22 @@ func (c *GitHubClient) DeleteReviewComment(ctx context.Context, owner, repo stri
 
 // ListLabels lists labels on a PR (issues API).
 func (c *GitHubClient) ListLabels(ctx context.Context, owner, repo string, prNumber int) ([]string, error) {
-	url := fmt.Sprintf("%s/repos/%s/%s/issues/%d/labels", c.apiURL, owner, repo, prNumber)
+	requestURL := c.apiURLf("/repos/%s/%s/issues/%d/labels", owner, repo, prNumber)
 
-	body, status, err := c.doRequest(ctx, http.MethodGet, url, nil)
+	body, status, err := c.doJSONRequest(ctx, http.MethodGet, requestURL, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	if status != http.StatusOK {
-		return nil, fmt.Errorf("GitHub API error (%d): %s", status, string(body))
+		return nil, githubAPIError(status, body)
 	}
 
 	var labels []struct {
 		Name string `json:"name"`
 	}
-	if err := json.Unmarshal(body, &labels); err != nil {
-		return nil, fmt.Errorf("failed to parse labels: %w", err)
+	if err := parseJSONResponse(body, &labels, "labels"); err != nil {
+		return nil, err
 	}
 
 	result := make([]string, 0, len(labels))
@@ -515,18 +532,18 @@ func (c *GitHubClient) AddLabels(ctx context.Context, owner, repo string, prNumb
 		return nil
 	}
 
-	url := fmt.Sprintf("%s/repos/%s/%s/issues/%d/labels", c.apiURL, owner, repo, prNumber)
+	requestURL := c.apiURLf("/repos/%s/%s/issues/%d/labels", owner, repo, prNumber)
 	payload := map[string][]string{
 		"labels": labels,
 	}
 
-	body, status, err := c.doRequest(ctx, http.MethodPost, url, payload)
+	body, status, err := c.doJSONRequest(ctx, http.MethodPost, requestURL, payload)
 	if err != nil {
 		return err
 	}
 
-	if status != http.StatusOK && status != http.StatusCreated {
-		return fmt.Errorf("GitHub API error (%d): %s", status, string(body))
+	if !expectStatus(status, http.StatusOK, http.StatusCreated) {
+		return githubAPIError(status, body)
 	}
 
 	return nil
@@ -534,15 +551,15 @@ func (c *GitHubClient) AddLabels(ctx context.Context, owner, repo string, prNumb
 
 // RemoveLabel removes a single label from a PR (issues API).
 func (c *GitHubClient) RemoveLabel(ctx context.Context, owner, repo string, prNumber int, label string) error {
-	url := fmt.Sprintf("%s/repos/%s/%s/issues/%d/labels/%s", c.apiURL, owner, repo, prNumber, url.PathEscape(label))
+	requestURL := c.apiURLf("/repos/%s/%s/issues/%d/labels/%s", owner, repo, prNumber, url.PathEscape(label))
 
-	body, status, err := c.doRequest(ctx, http.MethodDelete, url, nil)
+	body, status, err := c.doJSONRequest(ctx, http.MethodDelete, requestURL, nil)
 	if err != nil {
 		return err
 	}
 
-	if status != http.StatusOK && status != http.StatusNoContent && status != http.StatusNotFound {
-		return fmt.Errorf("GitHub API error (%d): %s", status, string(body))
+	if !expectStatus(status, http.StatusOK, http.StatusNoContent, http.StatusNotFound) {
+		return githubAPIError(status, body)
 	}
 
 	return nil
@@ -550,14 +567,14 @@ func (c *GitHubClient) RemoveLabel(ctx context.Context, owner, repo string, prNu
 
 // UpsertLabel creates or updates a repository label definition.
 func (c *GitHubClient) UpsertLabel(ctx context.Context, owner, repo, name, color, description string) error {
-	createURL := fmt.Sprintf("%s/repos/%s/%s/labels", c.apiURL, owner, repo)
+	createURL := c.apiURLf("/repos/%s/%s/labels", owner, repo)
 	payload := map[string]string{
 		"name":        name,
 		"color":       color,
 		"description": description,
 	}
 
-	body, status, err := c.doRequest(ctx, http.MethodPost, createURL, payload)
+	body, status, err := c.doJSONRequest(ctx, http.MethodPost, createURL, payload)
 	if err != nil {
 		return err
 	}
@@ -567,17 +584,17 @@ func (c *GitHubClient) UpsertLabel(ctx context.Context, owner, repo, name, color
 	}
 
 	if status != http.StatusUnprocessableEntity {
-		return fmt.Errorf("GitHub API error (%d): %s", status, string(body))
+		return githubAPIError(status, body)
 	}
 
-	updateURL := fmt.Sprintf("%s/repos/%s/%s/labels/%s", c.apiURL, owner, repo, url.PathEscape(name))
-	body, status, err = c.doRequest(ctx, http.MethodPatch, updateURL, payload)
+	updateURL := c.apiURLf("/repos/%s/%s/labels/%s", owner, repo, url.PathEscape(name))
+	body, status, err = c.doJSONRequest(ctx, http.MethodPatch, updateURL, payload)
 	if err != nil {
 		return err
 	}
 
 	if status != http.StatusOK {
-		return fmt.Errorf("GitHub API error (%d): %s", status, string(body))
+		return githubAPIError(status, body)
 	}
 
 	return nil

--- a/internal/github/github_client.go
+++ b/internal/github/github_client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/AtomicWasTaken/surge/internal/model"
@@ -225,7 +226,7 @@ func (c *GitHubClient) GetFiles(ctx context.Context, owner, repo string, prNumbe
 
 // GetFileContent fetches the content of a specific file at a given ref.
 func (c *GitHubClient) GetFileContent(ctx context.Context, owner, repo, path, ref string) (string, error) {
-	requestURL := c.apiURLf("/repos/%s/%s/contents/%s?ref=%s", owner, repo, path, ref)
+	requestURL := c.contentsURL(owner, repo, path, ref)
 
 	body, status, err := c.doJSONRequest(ctx, http.MethodGet, requestURL, nil)
 	if err != nil {
@@ -254,6 +255,27 @@ func (c *GitHubClient) GetFileContent(ctx context.Context, owner, repo, path, re
 	}
 
 	return string(decoded), nil
+}
+
+func (c *GitHubClient) contentsURL(owner, repo, path, ref string) string {
+	query := url.Values{}
+	query.Set("ref", ref)
+
+	return c.apiURLf(
+		"/repos/%s/%s/contents/%s?%s",
+		owner,
+		repo,
+		escapeGitHubContentPath(path),
+		query.Encode(),
+	)
+}
+
+func escapeGitHubContentPath(path string) string {
+	parts := strings.Split(path, "/")
+	for i, part := range parts {
+		parts[i] = url.PathEscape(part)
+	}
+	return strings.Join(parts, "/")
 }
 
 // PostReview posts a review with inline comments and a summary.

--- a/internal/github/github_client_test.go
+++ b/internal/github/github_client_test.go
@@ -44,3 +44,31 @@ func TestDismissReviewUsesDocumentedPayload(t *testing.T) {
 		"message": "Superseded by a newer surge review run.",
 	}, gotBody)
 }
+
+func TestGetFileContentEscapesPathAndRef(t *testing.T) {
+	var (
+		gotPath     string
+		gotURI      string
+		gotRawQuery string
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotURI = r.RequestURI
+		gotRawQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"content":"aGVsbG8=","encoding":"base64"}`))
+	}))
+	defer server.Close()
+
+	client := NewGitHubClient("test-token")
+	client.apiURL = server.URL
+
+	content, err := client.GetFileContent(context.Background(), "octo", "surge", "dir with spaces/a#b?.go", "feature/test branch")
+	require.NoError(t, err)
+
+	assert.Equal(t, "hello", content)
+	assert.Equal(t, "/repos/octo/surge/contents/dir with spaces/a#b?.go", gotPath)
+	assert.Equal(t, "/repos/octo/surge/contents/dir%20with%20spaces/a%23b%3F.go?ref=feature%2Ftest+branch", gotURI)
+	assert.Equal(t, "ref=feature%2Ftest+branch", gotRawQuery)
+}

--- a/internal/github/github_client_test.go
+++ b/internal/github/github_client_test.go
@@ -47,13 +47,13 @@ func TestDismissReviewUsesDocumentedPayload(t *testing.T) {
 
 func TestGetFileContentEscapesPathAndRef(t *testing.T) {
 	var (
-		gotPath     string
-		gotURI      string
-		gotRawQuery string
+		gotEscapedPath string
+		gotURI         string
+		gotRawQuery    string
 	)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
+		gotEscapedPath = r.URL.EscapedPath()
 		gotURI = r.RequestURI
 		gotRawQuery = r.URL.RawQuery
 		w.WriteHeader(http.StatusOK)
@@ -68,7 +68,7 @@ func TestGetFileContentEscapesPathAndRef(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "hello", content)
-	assert.Equal(t, "/repos/octo/surge/contents/dir with spaces/a#b?.go", gotPath)
+	assert.Equal(t, "/repos/octo/surge/contents/dir%20with%20spaces/a%23b%3F.go", gotEscapedPath)
 	assert.Equal(t, "/repos/octo/surge/contents/dir%20with%20spaces/a%23b%3F.go?ref=feature%2Ftest+branch", gotURI)
 	assert.Equal(t, "ref=feature%2Ftest+branch", gotRawQuery)
 }

--- a/internal/github/github_client_test.go
+++ b/internal/github/github_client_test.go
@@ -72,3 +72,14 @@ func TestGetFileContentEscapesPathAndRef(t *testing.T) {
 	assert.Equal(t, "/repos/octo/surge/contents/dir%20with%20spaces/a%23b%3F.go?ref=feature%2Ftest+branch", gotURI)
 	assert.Equal(t, "ref=feature%2Ftest+branch", gotRawQuery)
 }
+
+func TestExpectStatus(t *testing.T) {
+	assert.True(t, expectStatus(http.StatusCreated, http.StatusOK, http.StatusCreated))
+	assert.False(t, expectStatus(http.StatusBadRequest, http.StatusOK, http.StatusCreated))
+}
+
+func TestGitHubAPIError(t *testing.T) {
+	err := githubAPIError(http.StatusBadGateway, []byte(`{"message":"upstream failed"}`))
+	require.Error(t, err)
+	assert.Equal(t, `GitHub API error (502): {"message":"upstream failed"}`, err.Error())
+}

--- a/internal/model/review.go
+++ b/internal/model/review.go
@@ -6,6 +6,7 @@ type ReviewResult struct {
 	FilesOverview   []FileOverview `json:"filesOverview"`
 	Findings        []Finding      `json:"findings"`
 	VibeCheck       VibeCheck      `json:"vibeCheck"`
+	Warnings        []string       `json:"warnings,omitempty"`
 	Recommendations []string       `json:"recommendations"`
 	Approve         bool           `json:"approve"`
 	Stats           ReviewStats    `json:"stats,omitempty"`

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -26,7 +26,8 @@ func (j *JSONOutput) Render(result *model.ReviewResult) string {
 			"verdict": result.VibeCheck.Verdict,
 			"flags":   result.VibeCheck.Flags,
 		},
-		"findings": result.Findings,
+		"findings":        result.Findings,
+		"warnings":        result.Warnings,
 		"recommendations": result.Recommendations,
 		"approve":         result.Approve,
 		"stats": map[string]interface{}{

--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -75,6 +75,14 @@ func (m *MarkdownOutput) RenderSummary(result *model.ReviewResult) string {
 	sb.WriteString(result.Summary)
 	sb.WriteString("\n\n")
 
+	if len(result.Warnings) > 0 {
+		sb.WriteString("## Warnings\n\n")
+		for _, warning := range result.Warnings {
+			sb.WriteString(fmt.Sprintf("- %s\n", warning))
+		}
+		sb.WriteString("\n")
+	}
+
 	// Files Overview
 	if len(result.FilesOverview) > 0 {
 		sb.WriteString("<details>\n")

--- a/internal/output/terminal.go
+++ b/internal/output/terminal.go
@@ -19,10 +19,10 @@ func NewTerminalOutput() *TerminalOutput {
 	return &TerminalOutput{
 		severityStyle: map[model.Severity]lipgloss.Style{
 			model.SeverityCritical: lipgloss.NewStyle().Foreground(lipgloss.Color("#FF0000")).Bold(true),
-			model.SeverityHigh:    lipgloss.NewStyle().Foreground(lipgloss.Color("#FF8C00")).Bold(true),
-			model.SeverityMedium:  lipgloss.NewStyle().Foreground(lipgloss.Color("#FFD700")),
-			model.SeverityLow:    lipgloss.NewStyle().Foreground(lipgloss.Color("#1E90FF")),
-			model.SeverityInfo:   lipgloss.NewStyle().Foreground(lipgloss.Color("#808080")),
+			model.SeverityHigh:     lipgloss.NewStyle().Foreground(lipgloss.Color("#FF8C00")).Bold(true),
+			model.SeverityMedium:   lipgloss.NewStyle().Foreground(lipgloss.Color("#FFD700")),
+			model.SeverityLow:      lipgloss.NewStyle().Foreground(lipgloss.Color("#1E90FF")),
+			model.SeverityInfo:     lipgloss.NewStyle().Foreground(lipgloss.Color("#808080")),
 		},
 	}
 }
@@ -39,6 +39,15 @@ func (t *TerminalOutput) Render(result *model.ReviewResult) {
 		fmt.Println("  " + line)
 	}
 	fmt.Println()
+
+	if len(result.Warnings) > 0 {
+		fmt.Println("  Warnings")
+		fmt.Println(strings.Repeat("─", 60))
+		for _, warning := range result.Warnings {
+			RenderWarning(warning)
+		}
+		fmt.Println()
+	}
 
 	// Findings
 	if len(result.Findings) > 0 {

--- a/internal/review/orchestrator.go
+++ b/internal/review/orchestrator.go
@@ -86,17 +86,17 @@ func (o *Orchestrator) Review(ctx context.Context, owner, repo string, prNumber 
 	if depth == "" {
 		depth = ContextDepthDiffOnly
 	}
+	if err := o.enrichPRContext(ctx, owner, repo, pr, prCtx, depth); err != nil {
+		return nil, fmt.Errorf("failed to load PR context: %w", err)
+	}
 
 	// Step 5: Build and send AI request
-	systemPrompt := o.prompts.SystemPrompt()
+	systemPrompt := o.filterCategories()
 	userPrompt := o.prompts.BuildUserPrompt(prCtx, depth)
-
-	// Filter categories based on config
-	categories := o.filterCategories(systemPrompt)
 
 	aiReq := &ai.CompletionRequest{
 		Model:  o.cfg.AI.Model,
-		System: categories,
+		System: systemPrompt,
 		Messages: []ai.Message{
 			{Role: "user", Content: userPrompt},
 		},
@@ -105,7 +105,7 @@ func (o *Orchestrator) Review(ctx context.Context, owner, repo string, prNumber 
 		Debug:       o.cfg.Verbose,
 	}
 	if o.cfg.Verbose {
-		fmt.Printf("[debug] prompt sizes system_chars=%d user_chars=%d\n", len(categories), len(userPrompt))
+		fmt.Printf("[debug] prompt sizes system_chars=%d user_chars=%d\n", len(systemPrompt), len(userPrompt))
 	}
 
 	aiResp, err := o.aiClient.Complete(ctx, aiReq)
@@ -169,13 +169,54 @@ func (o *Orchestrator) buildPRContext(pr *model.PR, files []model.FileChange) *P
 	return prCtx
 }
 
-func (o *Orchestrator) filterCategories(systemPrompt string) string {
-	// The system prompt already includes all categories.
-	// We could strip unused categories from the prompt, but for simplicity
-	// we include all and let the AI focus on what matters.
-	// For a more optimized approach, we could modify the prompt here.
-	_ = systemPrompt
-	return o.prompts.SystemPrompt()
+func (o *Orchestrator) enrichPRContext(ctx context.Context, owner, repo string, pr *model.PR, prCtx *PRContext, depth ContextDepth) error {
+	if depth != ContextDepthFull {
+		return nil
+	}
+
+	for i := range prCtx.Files {
+		if !supportsFileContent(prCtx.Files[i].Status) {
+			continue
+		}
+
+		content, err := o.ghClient.GetFileContent(ctx, owner, repo, prCtx.Files[i].Path, pr.HeadSHA)
+		if err != nil {
+			return fmt.Errorf("load %s at %s: %w", prCtx.Files[i].Path, pr.HeadSHA, err)
+		}
+		prCtx.Files[i].Content = content
+	}
+
+	return nil
+}
+
+func (o *Orchestrator) filterCategories() string {
+	return o.prompts.SystemPromptForCategories(o.enabledCategories())
+}
+
+func (o *Orchestrator) enabledCategories() []model.Category {
+	var categories []model.Category
+
+	if o.cfg.Categories.Security {
+		categories = append(categories, model.CategorySecurity)
+	}
+	if o.cfg.Categories.Performance {
+		categories = append(categories, model.CategoryPerformance)
+	}
+	if o.cfg.Categories.Logic {
+		categories = append(categories, model.CategoryLogic)
+	}
+	if o.cfg.Categories.Maintainability {
+		categories = append(categories, model.CategoryMaintainability)
+	}
+	if o.cfg.Categories.Vibe {
+		categories = append(categories, model.CategoryVibe)
+	}
+
+	return categories
+}
+
+func supportsFileContent(status string) bool {
+	return status != string(model.FileStatusDeleted)
 }
 
 func (o *Orchestrator) postReview(ctx context.Context, owner, repo string, prNumber int, result *model.ReviewResult, files []model.FileChange) error {

--- a/internal/review/orchestrator.go
+++ b/internal/review/orchestrator.go
@@ -42,6 +42,11 @@ type cleanupStats struct {
 	failedOperations      int
 }
 
+type contextWarning struct {
+	path string
+	err  error
+}
+
 // NewOrchestrator creates a new review orchestrator.
 func NewOrchestrator(aiClient ai.AIClient, ghClient github.PRClient, cfg *config.Config) *Orchestrator {
 	return &Orchestrator{
@@ -86,7 +91,8 @@ func (o *Orchestrator) Review(ctx context.Context, owner, repo string, prNumber 
 	if depth == "" {
 		depth = ContextDepthDiffOnly
 	}
-	if err := o.enrichPRContext(ctx, owner, repo, pr, prCtx, depth); err != nil {
+	contextWarnings, err := o.enrichPRContext(ctx, owner, repo, pr, prCtx, depth)
+	if err != nil {
 		return nil, fmt.Errorf("failed to load PR context: %w", err)
 	}
 
@@ -129,6 +135,7 @@ func (o *Orchestrator) Review(ctx context.Context, owner, repo string, prNumber 
 		TokensOut:     aiResp.TokensOut,
 		Duration:      time.Since(start).Seconds(),
 	}
+	result.Warnings = formatContextWarnings(contextWarnings)
 
 	// Step 9: Output
 	if o.cfg.Output.Format == "json" {
@@ -169,11 +176,12 @@ func (o *Orchestrator) buildPRContext(pr *model.PR, files []model.FileChange) *P
 	return prCtx
 }
 
-func (o *Orchestrator) enrichPRContext(ctx context.Context, owner, repo string, pr *model.PR, prCtx *PRContext, depth ContextDepth) error {
+func (o *Orchestrator) enrichPRContext(ctx context.Context, owner, repo string, pr *model.PR, prCtx *PRContext, depth ContextDepth) ([]contextWarning, error) {
 	if depth != ContextDepthFull {
-		return nil
+		return nil, nil
 	}
 
+	var warnings []contextWarning
 	for i := range prCtx.Files {
 		if !supportsFileContent(prCtx.Files[i].Status) {
 			continue
@@ -181,15 +189,13 @@ func (o *Orchestrator) enrichPRContext(ctx context.Context, owner, repo string, 
 
 		content, err := o.ghClient.GetFileContent(ctx, owner, repo, prCtx.Files[i].Path, pr.HeadSHA)
 		if err != nil {
-			if o.cfg.Verbose {
-				fmt.Printf("[debug] skipped full context for %s at %s: %v\n", prCtx.Files[i].Path, pr.HeadSHA, err)
-			}
+			warnings = append(warnings, contextWarning{path: prCtx.Files[i].Path, err: err})
 			continue
 		}
 		prCtx.Files[i].Content = content
 	}
 
-	return nil
+	return warnings, nil
 }
 
 func (o *Orchestrator) filterCategories() string {
@@ -220,6 +226,27 @@ func (o *Orchestrator) enabledCategories() []model.Category {
 
 func supportsFileContent(status string) bool {
 	return status != string(model.FileStatusDeleted)
+}
+
+func formatContextWarnings(warnings []contextWarning) []string {
+	if len(warnings) == 0 {
+		return nil
+	}
+
+	paths := make([]string, len(warnings))
+	for i, warning := range warnings {
+		paths[i] = warning.path
+	}
+
+	messages := []string{
+		fmt.Sprintf("Full context was only partially loaded; skipped %d file(s): %s.", len(warnings), strings.Join(paths, ", ")),
+	}
+
+	for _, warning := range warnings {
+		messages = append(messages, fmt.Sprintf("Skipped %s: %v.", warning.path, warning.err))
+	}
+
+	return messages
 }
 
 func (o *Orchestrator) postReview(ctx context.Context, owner, repo string, prNumber int, result *model.ReviewResult, files []model.FileChange) error {

--- a/internal/review/orchestrator.go
+++ b/internal/review/orchestrator.go
@@ -181,7 +181,10 @@ func (o *Orchestrator) enrichPRContext(ctx context.Context, owner, repo string, 
 
 		content, err := o.ghClient.GetFileContent(ctx, owner, repo, prCtx.Files[i].Path, pr.HeadSHA)
 		if err != nil {
-			return fmt.Errorf("load %s at %s: %w", prCtx.Files[i].Path, pr.HeadSHA, err)
+			if o.cfg.Verbose {
+				fmt.Printf("[debug] skipped full context for %s at %s: %v\n", prCtx.Files[i].Path, pr.HeadSHA, err)
+			}
+			continue
 		}
 		prCtx.Files[i].Content = content
 	}

--- a/internal/review/orchestrator.go
+++ b/internal/review/orchestrator.go
@@ -242,10 +242,6 @@ func formatContextWarnings(warnings []contextWarning) []string {
 		fmt.Sprintf("Full context was only partially loaded; skipped %d file(s): %s.", len(warnings), strings.Join(paths, ", ")),
 	}
 
-	for _, warning := range warnings {
-		messages = append(messages, fmt.Sprintf("Skipped %s: %v.", warning.path, warning.err))
-	}
-
 	return messages
 }
 

--- a/internal/review/orchestrator.go
+++ b/internal/review/orchestrator.go
@@ -242,7 +242,31 @@ func formatContextWarnings(warnings []contextWarning) []string {
 		fmt.Sprintf("Full context was only partially loaded; skipped %d file(s): %s.", len(warnings), strings.Join(paths, ", ")),
 	}
 
+	reasons := make([]string, len(warnings))
+	for i, warning := range warnings {
+		reasons[i] = fmt.Sprintf("%s (%s)", warning.path, sanitizeContextWarningReason(warning.err))
+	}
+	messages = append(messages, "Skip reasons: "+strings.Join(reasons, ", ")+".")
+
 	return messages
+}
+
+func sanitizeContextWarningReason(err error) string {
+	if err == nil {
+		return "unknown error"
+	}
+
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "not found"):
+		return "not found"
+	case strings.Contains(msg, "forbidden"), strings.Contains(msg, "unauthorized"), strings.Contains(msg, "permission"):
+		return "permission denied"
+	case strings.Contains(msg, "timeout"), strings.Contains(msg, "deadline exceeded"):
+		return "timeout"
+	default:
+		return "request failed"
+	}
 }
 
 func (o *Orchestrator) postReview(ctx context.Context, owner, repo string, prNumber int, result *model.ReviewResult, files []model.FileChange) error {

--- a/internal/review/orchestrator_test.go
+++ b/internal/review/orchestrator_test.go
@@ -447,6 +447,15 @@ func TestFormatContextWarnings(t *testing.T) {
 		{path: "b.go", err: errors.New("forbidden")},
 	})
 
-	require.Len(t, warnings, 1)
+	require.Len(t, warnings, 2)
 	assert.Equal(t, "Full context was only partially loaded; skipped 2 file(s): a.go, b.go.", warnings[0])
+	assert.Equal(t, "Skip reasons: a.go (not found), b.go (permission denied).", warnings[1])
+}
+
+func TestSanitizeContextWarningReason(t *testing.T) {
+	assert.Equal(t, "not found", sanitizeContextWarningReason(errors.New("file not found")))
+	assert.Equal(t, "permission denied", sanitizeContextWarningReason(errors.New("forbidden by policy")))
+	assert.Equal(t, "timeout", sanitizeContextWarningReason(errors.New("deadline exceeded")))
+	assert.Equal(t, "request failed", sanitizeContextWarningReason(errors.New("bad gateway")))
+	assert.Equal(t, "unknown error", sanitizeContextWarningReason(nil))
 }

--- a/internal/review/orchestrator_test.go
+++ b/internal/review/orchestrator_test.go
@@ -19,6 +19,8 @@ type stubPRClient struct {
 	comments                []*model.PRComment
 	reviews                 []*model.PRReview
 	reviewComments          map[int64][]*model.PRReviewComment
+	fileContents            map[string]string
+	fileContentErrs         map[string]error
 	deletedIssueCommentIDs  []int64
 	deletedReviewCommentIDs []int64
 	deletedReviewIDs        []int64
@@ -49,7 +51,11 @@ func (s *stubPRClient) GetFiles(ctx context.Context, owner, repo string, prNumbe
 }
 
 func (s *stubPRClient) GetFileContent(ctx context.Context, owner, repo, path, ref string) (string, error) {
-	return "", nil
+	key := path + "@" + ref
+	if err := s.fileContentErrs[key]; err != nil {
+		return "", err
+	}
+	return s.fileContents[key], nil
 }
 
 func (s *stubPRClient) PostReview(ctx context.Context, owner, repo string, prNumber int, review *model.ReviewInput) error {
@@ -363,4 +369,46 @@ func TestIsSurgeCommentRecognizesCurrentAndLegacyMarkers(t *testing.T) {
 	assert.True(t, o.isSurgeComment("<!-- SURGE_SUMMARY -->"))
 	assert.True(t, o.isSurgeComment(output.ScopedCommentMarker("SURGE", output.CommentScopeInline)))
 	assert.False(t, o.isSurgeComment("plain comment"))
+}
+
+func TestOrchestratorFilterCategoriesUsesEnabledConfig(t *testing.T) {
+	o := NewOrchestrator(nil, &stubPRClient{}, &config.Config{
+		Categories: config.CategoriesConfig{
+			Security:        true,
+			Performance:     false,
+			Logic:           true,
+			Maintainability: false,
+			Vibe:            false,
+		},
+	})
+
+	prompt := o.filterCategories()
+
+	assert.Contains(t, prompt, "- security:")
+	assert.Contains(t, prompt, "- logic:")
+	assert.NotContains(t, prompt, "- performance:")
+	assert.NotContains(t, prompt, "- maintainability:")
+	assert.NotContains(t, prompt, "- vibe:")
+}
+
+func TestEnrichPRContextLoadsFullFileContent(t *testing.T) {
+	client := &stubPRClient{
+		fileContents: map[string]string{
+			"internal/app.go@abc123": "package app\n",
+		},
+	}
+	o := NewOrchestrator(nil, client, &config.Config{})
+	pr := &model.PR{HeadSHA: "abc123"}
+	prCtx := &PRContext{
+		Files: []FileContext{
+			{Path: "internal/app.go", Status: string(model.FileStatusModified)},
+			{Path: "internal/deleted.go", Status: string(model.FileStatusDeleted)},
+		},
+	}
+
+	err := o.enrichPRContext(context.Background(), "octo", "surge", pr, prCtx, ContextDepthFull)
+	require.NoError(t, err)
+
+	assert.Equal(t, "package app\n", prCtx.Files[0].Content)
+	assert.Empty(t, prCtx.Files[1].Content)
 }

--- a/internal/review/orchestrator_test.go
+++ b/internal/review/orchestrator_test.go
@@ -412,3 +412,28 @@ func TestEnrichPRContextLoadsFullFileContent(t *testing.T) {
 	assert.Equal(t, "package app\n", prCtx.Files[0].Content)
 	assert.Empty(t, prCtx.Files[1].Content)
 }
+
+func TestEnrichPRContextContinuesWhenFileContentLookupFails(t *testing.T) {
+	client := &stubPRClient{
+		fileContents: map[string]string{
+			"internal/ok.go@abc123": "package ok\n",
+		},
+		fileContentErrs: map[string]error{
+			"internal/missing.go@abc123": errors.New("not found"),
+		},
+	}
+	o := NewOrchestrator(nil, client, &config.Config{})
+	pr := &model.PR{HeadSHA: "abc123"}
+	prCtx := &PRContext{
+		Files: []FileContext{
+			{Path: "internal/ok.go", Status: string(model.FileStatusModified)},
+			{Path: "internal/missing.go", Status: string(model.FileStatusModified)},
+		},
+	}
+
+	err := o.enrichPRContext(context.Background(), "octo", "surge", pr, prCtx, ContextDepthFull)
+	require.NoError(t, err)
+
+	assert.Equal(t, "package ok\n", prCtx.Files[0].Content)
+	assert.Empty(t, prCtx.Files[1].Content)
+}

--- a/internal/review/orchestrator_test.go
+++ b/internal/review/orchestrator_test.go
@@ -406,8 +406,9 @@ func TestEnrichPRContextLoadsFullFileContent(t *testing.T) {
 		},
 	}
 
-	err := o.enrichPRContext(context.Background(), "octo", "surge", pr, prCtx, ContextDepthFull)
+	warnings, err := o.enrichPRContext(context.Background(), "octo", "surge", pr, prCtx, ContextDepthFull)
 	require.NoError(t, err)
+	assert.Empty(t, warnings)
 
 	assert.Equal(t, "package app\n", prCtx.Files[0].Content)
 	assert.Empty(t, prCtx.Files[1].Content)
@@ -431,9 +432,23 @@ func TestEnrichPRContextContinuesWhenFileContentLookupFails(t *testing.T) {
 		},
 	}
 
-	err := o.enrichPRContext(context.Background(), "octo", "surge", pr, prCtx, ContextDepthFull)
+	warnings, err := o.enrichPRContext(context.Background(), "octo", "surge", pr, prCtx, ContextDepthFull)
 	require.NoError(t, err)
+	require.Len(t, warnings, 1)
+	assert.Equal(t, "internal/missing.go", warnings[0].path)
 
 	assert.Equal(t, "package ok\n", prCtx.Files[0].Content)
 	assert.Empty(t, prCtx.Files[1].Content)
+}
+
+func TestFormatContextWarnings(t *testing.T) {
+	warnings := formatContextWarnings([]contextWarning{
+		{path: "a.go", err: errors.New("not found")},
+		{path: "b.go", err: errors.New("forbidden")},
+	})
+
+	require.Len(t, warnings, 3)
+	assert.Equal(t, "Full context was only partially loaded; skipped 2 file(s): a.go, b.go.", warnings[0])
+	assert.Equal(t, "Skipped a.go: not found.", warnings[1])
+	assert.Equal(t, "Skipped b.go: forbidden.", warnings[2])
 }

--- a/internal/review/orchestrator_test.go
+++ b/internal/review/orchestrator_test.go
@@ -447,8 +447,6 @@ func TestFormatContextWarnings(t *testing.T) {
 		{path: "b.go", err: errors.New("forbidden")},
 	})
 
-	require.Len(t, warnings, 3)
+	require.Len(t, warnings, 1)
 	assert.Equal(t, "Full context was only partially loaded; skipped 2 file(s): a.go, b.go.", warnings[0])
-	assert.Equal(t, "Skipped a.go: not found.", warnings[1])
-	assert.Equal(t, "Skipped b.go: forbidden.", warnings[2])
 }

--- a/internal/review/prompts.go
+++ b/internal/review/prompts.go
@@ -129,6 +129,7 @@ RULES:
 - If the PR is good, approve=true with a brief note. If there are issues, approve=false.
 - Always include a vibe check. Every codebase deserves a vibe assessment.
 - Only emit findings whose category is in the enabled category list above.
+- If the enabled category list says none, you must return "findings": [].
 - JSON must be valid. No trailing commas. No comments in the JSON.`
 }
 

--- a/internal/review/prompts.go
+++ b/internal/review/prompts.go
@@ -211,7 +211,7 @@ func (pb *PromptBuilder) formatCategoryDefinitions(categories []model.Category) 
 	}
 
 	if len(lines) == 0 {
-		return "- maintainability: Code duplication, complex functions, poor naming, missing tests"
+		return "- none: No review categories are enabled for this run."
 	}
 
 	return strings.Join(lines, "\n")

--- a/internal/review/prompts.go
+++ b/internal/review/prompts.go
@@ -3,6 +3,8 @@ package review
 import (
 	"fmt"
 	"strings"
+
+	"github.com/AtomicWasTaken/surge/internal/model"
 )
 
 // ContextDepth controls how much codebase context the AI receives.
@@ -11,15 +13,15 @@ type ContextDepth string
 const (
 	ContextDepthDiffOnly ContextDepth = "diff-only"
 	ContextDepthRelevant ContextDepth = "relevant"
-	ContextDepthFull    ContextDepth = "full"
+	ContextDepthFull     ContextDepth = "full"
 )
 
 // PRContext holds the context needed to build a review prompt.
 type PRContext struct {
-	Title       string
-	Body        string
+	Title        string
+	Body         string
 	ChangedFiles int
-	Files       []FileContext
+	Files        []FileContext
 }
 
 // FileContext holds context for a single changed file.
@@ -35,6 +37,17 @@ type FileContext struct {
 // PromptBuilder constructs prompts for the AI code reviewer.
 type PromptBuilder struct{}
 
+var categoryDefinitions = []struct {
+	name        model.Category
+	description string
+}{
+	{name: model.CategorySecurity, description: "Vulnerabilities, auth issues, data exposure, injection risks"},
+	{name: model.CategoryPerformance, description: "N+1 queries, missing indexes, inefficient algorithms, memory leaks"},
+	{name: model.CategoryLogic, description: "Off-by-one errors, race conditions, incorrect business logic"},
+	{name: model.CategoryMaintainability, description: "Code duplication, complex functions, poor naming, missing tests"},
+	{name: model.CategoryVibe, description: "Generic AI-generated patterns, context blindness, over-engineering, wrong/confused outputs"},
+}
+
 // NewPromptBuilder creates a new prompt builder.
 func NewPromptBuilder() *PromptBuilder {
 	return &PromptBuilder{}
@@ -42,6 +55,16 @@ func NewPromptBuilder() *PromptBuilder {
 
 // SystemPrompt returns the system prompt for the AI reviewer.
 func (pb *PromptBuilder) SystemPrompt() string {
+	return pb.SystemPromptForCategories(nil)
+}
+
+// SystemPromptForCategories returns the system prompt scoped to the configured categories.
+func (pb *PromptBuilder) SystemPromptForCategories(categories []model.Category) string {
+	enabledCategories := categories
+	if len(enabledCategories) == 0 {
+		enabledCategories = enabledReviewCategories()
+	}
+
 	return `You are surge, an expert AI-powered code reviewer. You analyze pull request
 diffs and provide structured, actionable feedback. You are direct, specific,
 and avoid generic advice. You never say "looks good" without specifics.
@@ -79,11 +102,7 @@ SEVERITY DEFINITIONS:
 - INFO: Suggestions, tips, improvements, optimizations
 
 CATEGORIES:
-- security: Vulnerabilities, auth issues, data exposure, injection risks
-- performance: N+1 queries, missing indexes, inefficient algorithms, memory leaks
-- logic: Off-by-one errors, race conditions, incorrect business logic
-- maintainability: Code duplication, complex functions, poor naming, missing tests
-- vibe: Generic AI-generated patterns, context blindness, over-engineering, wrong/confused outputs
+` + pb.formatCategoryDefinitions(enabledCategories) + `
 
 VIBE CODABILITY SCORING:
 - 10: Perfect. Code that feels hand-crafted, idiomatic, project-aware.
@@ -109,6 +128,7 @@ RULES:
 - For each finding, include the specific file path and line number if possible.
 - If the PR is good, approve=true with a brief note. If there are issues, approve=false.
 - Always include a vibe check. Every codebase deserves a vibe assessment.
+- Only emit findings whose category is in the enabled category list above.
 - JSON must be valid. No trailing commas. No comments in the JSON.`
 }
 
@@ -174,4 +194,35 @@ func (pb *PromptBuilder) BuildUserPrompt(pr *PRContext, depth ContextDepth) stri
 	sb.WriteString("\nProvide your review in the required JSON format.")
 
 	return sb.String()
+}
+
+func (pb *PromptBuilder) formatCategoryDefinitions(categories []model.Category) string {
+	enabled := make(map[model.Category]struct{}, len(categories))
+	for _, category := range categories {
+		enabled[category] = struct{}{}
+	}
+
+	lines := make([]string, 0, len(categoryDefinitions))
+	for _, definition := range categoryDefinitions {
+		if _, ok := enabled[definition.name]; !ok {
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("- %s: %s", definition.name, definition.description))
+	}
+
+	if len(lines) == 0 {
+		return "- maintainability: Code duplication, complex functions, poor naming, missing tests"
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func enabledReviewCategories() []model.Category {
+	return []model.Category{
+		model.CategorySecurity,
+		model.CategoryPerformance,
+		model.CategoryLogic,
+		model.CategoryMaintainability,
+		model.CategoryVibe,
+	}
 }

--- a/internal/review/prompts.go
+++ b/internal/review/prompts.go
@@ -61,7 +61,7 @@ func (pb *PromptBuilder) SystemPrompt() string {
 // SystemPromptForCategories returns the system prompt scoped to the configured categories.
 func (pb *PromptBuilder) SystemPromptForCategories(categories []model.Category) string {
 	enabledCategories := categories
-	if len(enabledCategories) == 0 {
+	if enabledCategories == nil {
 		enabledCategories = enabledReviewCategories()
 	}
 

--- a/internal/review/review_test.go
+++ b/internal/review/review_test.go
@@ -131,6 +131,7 @@ func TestPromptBuilder_SystemPromptForCategoriesEmptySet(t *testing.T) {
 	prompt := pb.SystemPromptForCategories([]model.Category{})
 
 	assert.Contains(t, prompt, "- none: No review categories are enabled for this run.")
+	assert.Contains(t, prompt, `If the enabled category list says none, you must return "findings": [].`)
 	assert.NotContains(t, prompt, "- security:")
 	assert.NotContains(t, prompt, "- performance:")
 	assert.NotContains(t, prompt, "- logic:")

--- a/internal/review/review_test.go
+++ b/internal/review/review_test.go
@@ -126,6 +126,23 @@ func TestPromptBuilder_SystemPromptForCategories(t *testing.T) {
 	assert.Contains(t, prompt, "Only emit findings whose category is in the enabled category list above.")
 }
 
+func TestPromptBuilder_SystemPromptForCategoriesEmptySet(t *testing.T) {
+	pb := NewPromptBuilder()
+	prompt := pb.SystemPromptForCategories([]model.Category{})
+
+	assert.Contains(t, prompt, "- security:")
+	assert.Contains(t, prompt, "- performance:")
+	assert.Contains(t, prompt, "- logic:")
+	assert.Contains(t, prompt, "- maintainability:")
+	assert.Contains(t, prompt, "- vibe:")
+	assert.NotContains(t, prompt, "- none:")
+}
+
+func TestPromptBuilderFormatCategoryDefinitionsEmptySet(t *testing.T) {
+	pb := NewPromptBuilder()
+	assert.Equal(t, "- none: No review categories are enabled for this run.", pb.formatCategoryDefinitions([]model.Category{}))
+}
+
 func TestPromptBuilder_BuildUserPrompt(t *testing.T) {
 	pb := NewPromptBuilder()
 

--- a/internal/review/review_test.go
+++ b/internal/review/review_test.go
@@ -130,17 +130,29 @@ func TestPromptBuilder_SystemPromptForCategoriesEmptySet(t *testing.T) {
 	pb := NewPromptBuilder()
 	prompt := pb.SystemPromptForCategories([]model.Category{})
 
+	assert.Contains(t, prompt, "- none: No review categories are enabled for this run.")
+	assert.NotContains(t, prompt, "- security:")
+	assert.NotContains(t, prompt, "- performance:")
+	assert.NotContains(t, prompt, "- logic:")
+	assert.NotContains(t, prompt, "- maintainability:")
+	assert.NotContains(t, prompt, "- vibe:")
+}
+
+func TestPromptBuilderFormatCategoryDefinitionsEmptySet(t *testing.T) {
+	pb := NewPromptBuilder()
+	assert.Equal(t, "- none: No review categories are enabled for this run.", pb.formatCategoryDefinitions([]model.Category{}))
+}
+
+func TestPromptBuilderSystemPromptForCategoriesNilUsesDefaults(t *testing.T) {
+	pb := NewPromptBuilder()
+	prompt := pb.SystemPromptForCategories(nil)
+
 	assert.Contains(t, prompt, "- security:")
 	assert.Contains(t, prompt, "- performance:")
 	assert.Contains(t, prompt, "- logic:")
 	assert.Contains(t, prompt, "- maintainability:")
 	assert.Contains(t, prompt, "- vibe:")
 	assert.NotContains(t, prompt, "- none:")
-}
-
-func TestPromptBuilderFormatCategoryDefinitionsEmptySet(t *testing.T) {
-	pb := NewPromptBuilder()
-	assert.Equal(t, "- none: No review categories are enabled for this run.", pb.formatCategoryDefinitions([]model.Category{}))
 }
 
 func TestPromptBuilder_BuildUserPrompt(t *testing.T) {

--- a/internal/review/review_test.go
+++ b/internal/review/review_test.go
@@ -114,12 +114,24 @@ func TestPromptBuilder_SystemPrompt(t *testing.T) {
 	assert.Contains(t, prompt, "context_blind")
 }
 
+func TestPromptBuilder_SystemPromptForCategories(t *testing.T) {
+	pb := NewPromptBuilder()
+	prompt := pb.SystemPromptForCategories([]model.Category{model.CategorySecurity, model.CategoryLogic})
+
+	assert.Contains(t, prompt, "- security:")
+	assert.Contains(t, prompt, "- logic:")
+	assert.NotContains(t, prompt, "- performance:")
+	assert.NotContains(t, prompt, "- maintainability:")
+	assert.NotContains(t, prompt, "- vibe:")
+	assert.Contains(t, prompt, "Only emit findings whose category is in the enabled category list above.")
+}
+
 func TestPromptBuilder_BuildUserPrompt(t *testing.T) {
 	pb := NewPromptBuilder()
 
 	prCtx := &PRContext{
-		Title:       "Add user authentication",
-		Body:        "Implements JWT-based auth",
+		Title:        "Add user authentication",
+		Body:         "Implements JWT-based auth",
 		ChangedFiles: 2,
 		Files: []FileContext{
 			{Path: "auth.go", Status: "modified", Additions: 10, Deletions: 2, Patch: "+ JWT auth"},
@@ -141,14 +153,14 @@ func TestPromptBuilder_BuildUserPrompt_RelevantContext(t *testing.T) {
 	pb := NewPromptBuilder()
 
 	prCtx := &PRContext{
-		Title:       "Refactor database layer",
+		Title:        "Refactor database layer",
 		ChangedFiles: 1,
 		Files: []FileContext{
 			{
-				Path:     "db.go",
-				Status:   "modified",
-				Patch:    "@@ -1,3 +1,4 @@",
-				Content:  "full file content here",
+				Path:    "db.go",
+				Status:  "modified",
+				Patch:   "@@ -1,3 +1,4 @@",
+				Content: "full file content here",
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- split the review CLI flow into smaller config, target resolution, credential, and client construction helpers
- centralize config defaults, env bindings, and validation while keeping runtime behavior intact
- consolidate GitHub client request handling and wire full-context prompt enrichment plus category-aware prompt generation

## Testing
- go test ./...