### PR TITLE
Add AI agent fix suggestions and redesign review output

### DIFF
--- a/internal/model/review.go
+++ b/internal/model/review.go
@@ -25,8 +25,9 @@ type Finding struct {
 	Category Category `json:"category"`
 	File     string   `json:"file,omitempty"`
 	Line     int      `json:"line,omitempty"`
-	Title    string   `json:"title"`
-	Body     string   `json:"body"`
+	Title      string `json:"title"`
+	Body       string `json:"body"`
+	Suggestion string `json:"suggestion,omitempty"`
 }
 
 // Severity represents how severe a finding is.

--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -139,7 +139,7 @@ func (m *MarkdownOutput) RenderSummary(result *model.ReviewResult) string {
 				sb.WriteString("\n")
 				if f.Suggestion != "" {
 					sb.WriteString("\n**🤖 Agent fix prompt:**\n")
-					sb.WriteString(fmt.Sprintf("> %s\n", f.Suggestion))
+					sb.WriteString(fmt.Sprintf("> %s\n", SanitizeBlockquote(f.Suggestion)))
 				}
 				sb.WriteString("\n</details>\n\n")
 			}
@@ -235,6 +235,17 @@ func sanitizeTableCell(v string) string {
 
 func sanitizeInlineCode(v string) string {
 	return strings.ReplaceAll(v, "`", "")
+}
+
+// SanitizeBlockquote escapes markdown/HTML in text intended for blockquote rendering.
+// It collapses newlines into spaces so the blockquote stays on a single line,
+// escapes HTML tags, and removes leading > characters that could nest quotes.
+func SanitizeBlockquote(v string) string {
+	v = strings.ReplaceAll(v, "\n", " ")
+	v = strings.ReplaceAll(v, "\r", "")
+	v = strings.ReplaceAll(v, "<", "&lt;")
+	v = strings.ReplaceAll(v, ">", "&gt;")
+	return strings.TrimSpace(v)
 }
 
 func vibeBar(score int) string {

--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -93,14 +93,14 @@ func (m *MarkdownOutput) RenderSummary(result *model.ReviewResult) string {
 	sb.WriteString("\n")
 
 	// Summary
-	sb.WriteString(result.Summary)
+	sb.WriteString(SanitizeHTML(result.Summary))
 	sb.WriteString("\n\n")
 
 	if len(result.Warnings) > 0 {
 		sb.WriteString("<blockquote>\n\n")
 		sb.WriteString("⚠️ **Warnings**\n\n")
 		for _, warning := range result.Warnings {
-			sb.WriteString(fmt.Sprintf("- %s\n", warning))
+			sb.WriteString(fmt.Sprintf("- %s\n", SanitizeHTML(warning)))
 		}
 		sb.WriteString("\n</blockquote>\n\n")
 	}
@@ -135,12 +135,9 @@ func (m *MarkdownOutput) RenderSummary(result *model.ReviewResult) string {
 				sb.WriteString(fmt.Sprintf("<details>\n<summary>%s <strong>%s</strong> &nbsp;<code>%s</code></summary>\n\n",
 					emoji, sanitizeTableCell(f.Title), sanitizeInlineCode(location)))
 				sb.WriteString(fmt.Sprintf("**Category:** `%s` &nbsp;·&nbsp; **Severity:** %s\n\n", f.Category, severityLabel(sev)))
-				sb.WriteString(f.Body)
+				sb.WriteString(SanitizeHTML(f.Body))
 				sb.WriteString("\n")
-				if f.Suggestion != "" {
-					sb.WriteString("\n**🤖 Agent fix prompt:**\n")
-					sb.WriteString(fmt.Sprintf("> %s\n", SanitizeBlockquote(f.Suggestion)))
-				}
+				sb.WriteString(RenderAgentSuggestion(f.Suggestion))
 				sb.WriteString("\n</details>\n\n")
 			}
 		}
@@ -150,7 +147,7 @@ func (m *MarkdownOutput) RenderSummary(result *model.ReviewResult) string {
 
 	// Vibe Check (compact)
 	sb.WriteString("<details>\n")
-	sb.WriteString(fmt.Sprintf("<summary>🎯 Vibe Check &nbsp;·&nbsp; %d/10 &nbsp;—&nbsp; %s</summary>\n\n", result.VibeCheck.Score, result.VibeCheck.Verdict))
+	sb.WriteString(fmt.Sprintf("<summary>🎯 Vibe Check &nbsp;·&nbsp; %d/10 &nbsp;—&nbsp; %s</summary>\n\n", result.VibeCheck.Score, SanitizeHTML(result.VibeCheck.Verdict)))
 	if len(result.VibeCheck.Flags) > 0 {
 		sb.WriteString("**Flags:** ")
 		for i, flag := range result.VibeCheck.Flags {
@@ -168,7 +165,7 @@ func (m *MarkdownOutput) RenderSummary(result *model.ReviewResult) string {
 		sb.WriteString("<details>\n")
 		sb.WriteString("<summary>✅ Recommended next steps</summary>\n\n")
 		for _, rec := range result.Recommendations {
-			sb.WriteString(fmt.Sprintf("- [ ] %s\n", rec))
+			sb.WriteString(fmt.Sprintf("- [ ] %s\n", SanitizeHTML(rec)))
 		}
 		sb.WriteString("\n</details>\n\n")
 	}
@@ -246,6 +243,24 @@ func SanitizeBlockquote(v string) string {
 	v = strings.ReplaceAll(v, "<", "&lt;")
 	v = strings.ReplaceAll(v, ">", "&gt;")
 	return strings.TrimSpace(v)
+}
+
+// SanitizeHTML escapes raw HTML tags in model-generated text while preserving
+// markdown formatting (newlines, backticks, etc.). Use this for free-text fields
+// like summary, body, verdict, and warnings that render as markdown paragraphs.
+func SanitizeHTML(v string) string {
+	v = strings.ReplaceAll(v, "<", "&lt;")
+	v = strings.ReplaceAll(v, ">", "&gt;")
+	return v
+}
+
+// RenderAgentSuggestion formats a finding suggestion as a markdown agent fix prompt block.
+// Returns an empty string if the suggestion is empty.
+func RenderAgentSuggestion(suggestion string) string {
+	if suggestion == "" {
+		return ""
+	}
+	return fmt.Sprintf("\n**🤖 Agent fix prompt:**\n> %s\n", SanitizeBlockquote(suggestion))
 }
 
 func vibeBar(score int) string {

--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -89,6 +89,8 @@ func (m *MarkdownOutput) RenderSummary(result *model.ReviewResult) string {
 	}
 	if len(badges) > 0 {
 		sb.WriteString(fmt.Sprintf("> %s\n", strings.Join(badges, " &nbsp;·&nbsp; ")))
+	} else {
+		sb.WriteString("> ⚪ 0 findings\n")
 	}
 	sb.WriteString("\n")
 
@@ -226,10 +228,18 @@ func groupBySeverity(findings []model.Finding) map[model.Severity][]model.Findin
 	return result
 }
 
+// Markdown sanitization helpers — each targets a specific rendering context.
+// Use the appropriate helper for the output context to ensure consistent escaping.
+
+// sanitizeTableCell escapes pipe characters, HTML tags, and collapses newlines for table cells.
 func sanitizeTableCell(v string) string {
-	return strings.ReplaceAll(strings.ReplaceAll(v, "|", "\\|"), "\n", "<br>")
+	v = SanitizeHTML(v)
+	v = strings.ReplaceAll(v, "|", "\\|")
+	v = strings.ReplaceAll(v, "\n", "<br>")
+	return v
 }
 
+// sanitizeInlineCode strips backticks and escapes HTML for inline code spans.
 func sanitizeInlineCode(v string) string {
 	return strings.ReplaceAll(v, "`", "")
 }

--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -139,7 +139,11 @@ func (m *MarkdownOutput) RenderSummary(result *model.ReviewResult) string {
 				sb.WriteString(fmt.Sprintf("**Category:** `%s` &nbsp;·&nbsp; **Severity:** %s\n\n", f.Category, severityLabel(sev)))
 				sb.WriteString(SanitizeHTML(f.Body))
 				sb.WriteString("\n")
-				sb.WriteString(RenderAgentSuggestion(f.Suggestion))
+				if suggestion := RenderAgentSuggestion(f.Suggestion); suggestion != "" {
+					sb.WriteString("\n")
+					sb.WriteString(suggestion)
+					sb.WriteString("\n")
+				}
 				sb.WriteString("\n</details>\n\n")
 			}
 		}
@@ -239,7 +243,7 @@ func sanitizeTableCell(v string) string {
 	return v
 }
 
-// sanitizeInlineCode strips backticks and escapes HTML for inline code spans.
+// sanitizeInlineCode strips backticks to prevent breaking out of <code> spans.
 func sanitizeInlineCode(v string) string {
 	return strings.ReplaceAll(v, "`", "")
 }
@@ -265,12 +269,13 @@ func SanitizeHTML(v string) string {
 }
 
 // RenderAgentSuggestion formats a finding suggestion as a markdown agent fix prompt block.
-// Returns an empty string if the suggestion is empty.
+// Returns an empty string if the suggestion is empty. Callers are responsible for
+// surrounding whitespace/newlines.
 func RenderAgentSuggestion(suggestion string) string {
 	if suggestion == "" {
 		return ""
 	}
-	return fmt.Sprintf("\n**🤖 Agent fix prompt:**\n> %s\n", SanitizeBlockquote(suggestion))
+	return fmt.Sprintf("**🤖 Agent fix prompt:**\n> %s", SanitizeBlockquote(suggestion))
 }
 
 func vibeBar(score int) string {

--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -47,50 +47,72 @@ func (m *MarkdownOutput) RenderSummary(result *model.ReviewResult) string {
 	var sb strings.Builder
 	bySeverity := groupBySeverity(result.Findings)
 	findingCount := len(result.Findings)
-	decision := "✅ Approve"
+	decision := "✅ Approved"
 	if !result.Approve {
-		decision = "❌ Request Changes"
+		decision = "❌ Changes Requested"
 	}
 
 	sb.WriteString(CommentMarker(m.commentMarker))
 	sb.WriteString("\n")
 	sb.WriteString(ScopedCommentMarker(m.commentMarker, CommentScopeSummary))
 	sb.WriteString("\n")
-	sb.WriteString("## ⚡ surge Review Summary\n\n")
-	sb.WriteString("| Decision | Findings | Files | Vibe |\n")
-	sb.WriteString("|---|---:|---:|---:|\n")
-	sb.WriteString(fmt.Sprintf("| %s | %d | %d | %d/10 |\n\n", decision, findingCount, result.Stats.FilesReviewed, result.VibeCheck.Score))
 
-	sb.WriteString("### Severity Rollup\n\n")
-	sb.WriteString("| 🔴 Critical | 🟠 High | 🟡 Medium | 🔵 Low | ⚪ Info |\n")
-	sb.WriteString("|---:|---:|---:|---:|---:|\n")
-	sb.WriteString(fmt.Sprintf("| %d | %d | %d | %d | %d |\n\n",
-		len(bySeverity[model.SeverityCritical]),
-		len(bySeverity[model.SeverityHigh]),
-		len(bySeverity[model.SeverityMedium]),
-		len(bySeverity[model.SeverityLow]),
-		len(bySeverity[model.SeverityInfo])))
+	// Header with decision badge
+	sb.WriteString(fmt.Sprintf("## ⚡ surge &nbsp;·&nbsp; %s\n\n", decision))
 
-	sb.WriteString("### Executive Summary\n\n")
+	// Compact stats line
+	sb.WriteString(fmt.Sprintf("> **%d** findings across **%d** files &nbsp;·&nbsp; Vibe **%d/10** %s\n",
+		findingCount, result.Stats.FilesReviewed, result.VibeCheck.Score, vibeBar(result.VibeCheck.Score)))
+
+	// Severity badges inline
+	critCount := len(bySeverity[model.SeverityCritical])
+	highCount := len(bySeverity[model.SeverityHigh])
+	medCount := len(bySeverity[model.SeverityMedium])
+	lowCount := len(bySeverity[model.SeverityLow])
+	infoCount := len(bySeverity[model.SeverityInfo])
+
+	var badges []string
+	if critCount > 0 {
+		badges = append(badges, fmt.Sprintf("🔴 %d critical", critCount))
+	}
+	if highCount > 0 {
+		badges = append(badges, fmt.Sprintf("🟠 %d high", highCount))
+	}
+	if medCount > 0 {
+		badges = append(badges, fmt.Sprintf("🟡 %d medium", medCount))
+	}
+	if lowCount > 0 {
+		badges = append(badges, fmt.Sprintf("🔵 %d low", lowCount))
+	}
+	if infoCount > 0 {
+		badges = append(badges, fmt.Sprintf("⚪ %d info", infoCount))
+	}
+	if len(badges) > 0 {
+		sb.WriteString(fmt.Sprintf("> %s\n", strings.Join(badges, " &nbsp;·&nbsp; ")))
+	}
+	sb.WriteString("\n")
+
+	// Summary
 	sb.WriteString(result.Summary)
 	sb.WriteString("\n\n")
 
 	if len(result.Warnings) > 0 {
-		sb.WriteString("## Warnings\n\n")
+		sb.WriteString("<blockquote>\n\n")
+		sb.WriteString("⚠️ **Warnings**\n\n")
 		for _, warning := range result.Warnings {
 			sb.WriteString(fmt.Sprintf("- %s\n", warning))
 		}
-		sb.WriteString("\n")
+		sb.WriteString("\n</blockquote>\n\n")
 	}
 
-	// Files Overview
+	// Files Overview (collapsed)
 	if len(result.FilesOverview) > 0 {
 		sb.WriteString("<details>\n")
-		sb.WriteString("<summary><strong>📁 Files Changed Overview</strong></summary>\n\n")
+		sb.WriteString("<summary>📁 Files changed</summary>\n\n")
 		sb.WriteString("| File | Changes | Risk |\n")
-		sb.WriteString("|---|---|---|\n")
+		sb.WriteString("|---|---|---:|\n")
 		for _, f := range result.FilesOverview {
-			risk := riskEmoji(f.Risk) + " " + strings.ToUpper(f.Risk)
+			risk := riskEmoji(f.Risk) + " " + f.Risk
 			sb.WriteString(fmt.Sprintf("| `%s` | %s | %s |\n", sanitizeTableCell(f.Path), sanitizeTableCell(f.Changes), sanitizeTableCell(risk)))
 		}
 		sb.WriteString("\n</details>\n\n")
@@ -98,58 +120,62 @@ func (m *MarkdownOutput) RenderSummary(result *model.ReviewResult) string {
 
 	// Findings by Severity
 	if len(result.Findings) > 0 {
-		sb.WriteString("## 🧭 Findings\n\n")
+		sb.WriteString("### Findings\n\n")
 		for _, sev := range []model.Severity{model.SeverityCritical, model.SeverityHigh, model.SeverityMedium, model.SeverityLow, model.SeverityInfo} {
 			findings := bySeverity[sev]
 			if len(findings) == 0 {
 				continue
 			}
-			emoji := severityEmoji(sev)
-			sb.WriteString(fmt.Sprintf("### %s %s (%d)\n\n", emoji, severityLabel(sev), len(findings)))
-			for i, f := range findings {
+			for _, f := range findings {
 				location := f.File
 				if f.Line > 0 {
 					location = fmt.Sprintf("%s:%d", f.File, f.Line)
 				}
-				sb.WriteString("<details>\n")
-				sb.WriteString(fmt.Sprintf("<summary><strong>%s</strong> · <code>%s</code> · <code>%s</code></summary>\n\n",
-					sanitizeTableCell(f.Title), sanitizeInlineCode(location), f.Category))
+				emoji := severityEmoji(sev)
+				sb.WriteString(fmt.Sprintf("<details>\n<summary>%s <strong>%s</strong> &nbsp;<code>%s</code></summary>\n\n",
+					emoji, sanitizeTableCell(f.Title), sanitizeInlineCode(location)))
+				sb.WriteString(fmt.Sprintf("**Category:** `%s` &nbsp;·&nbsp; **Severity:** %s\n\n", f.Category, severityLabel(sev)))
 				sb.WriteString(f.Body)
-				sb.WriteString("\n\n</details>\n\n")
-				if i != len(findings)-1 {
-					sb.WriteString("---\n\n")
+				sb.WriteString("\n")
+				if f.Suggestion != "" {
+					sb.WriteString("\n**🤖 Agent fix prompt:**\n")
+					sb.WriteString(fmt.Sprintf("> %s\n", f.Suggestion))
 				}
+				sb.WriteString("\n</details>\n\n")
 			}
 		}
 	} else {
-		sb.WriteString("## 🧭 Findings\n\n")
-		sb.WriteString("No actionable findings were reported.\n\n")
+		sb.WriteString("### Findings\n\nNo issues found — nice work.\n\n")
 	}
 
-	// Vibe Check
-	sb.WriteString("## 🎯 Vibe Check\n\n")
-	sb.WriteString(fmt.Sprintf("**Score:** %d/10 %s\n\n", result.VibeCheck.Score, vibeBar(result.VibeCheck.Score)))
-	sb.WriteString(fmt.Sprintf("**Verdict:** %s\n\n", result.VibeCheck.Verdict))
+	// Vibe Check (compact)
+	sb.WriteString("<details>\n")
+	sb.WriteString(fmt.Sprintf("<summary>🎯 Vibe Check &nbsp;·&nbsp; %d/10 &nbsp;—&nbsp; %s</summary>\n\n", result.VibeCheck.Score, result.VibeCheck.Verdict))
 	if len(result.VibeCheck.Flags) > 0 {
-		sb.WriteString("**Flags**\n")
-		for _, flag := range result.VibeCheck.Flags {
-			sb.WriteString(fmt.Sprintf("- `%s`\n", flag))
+		sb.WriteString("**Flags:** ")
+		for i, flag := range result.VibeCheck.Flags {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			sb.WriteString(fmt.Sprintf("`%s`", flag))
 		}
 		sb.WriteString("\n")
 	}
+	sb.WriteString("\n</details>\n\n")
 
 	// Recommendations
 	if len(result.Recommendations) > 0 {
-		sb.WriteString("## ✅ Recommended Next Steps\n\n")
+		sb.WriteString("<details>\n")
+		sb.WriteString("<summary>✅ Recommended next steps</summary>\n\n")
 		for _, rec := range result.Recommendations {
 			sb.WriteString(fmt.Sprintf("- [ ] %s\n", rec))
 		}
-		sb.WriteString("\n")
+		sb.WriteString("\n</details>\n\n")
 	}
 
 	// Footer
-	sb.WriteString("---\n\n")
-	sb.WriteString("> Generated by [surge](https://github.com/AtomicWasTaken/surge) · AI-powered PR reviews\n")
+	sb.WriteString("---\n")
+	sb.WriteString("<sub>Generated by <a href=\"https://github.com/AtomicWasTaken/surge\">surge</a> · AI-powered PR reviews</sub>\n")
 
 	return sb.String()
 }

--- a/internal/output/markdown.go
+++ b/internal/output/markdown.go
@@ -133,7 +133,7 @@ func (m *MarkdownOutput) RenderSummary(result *model.ReviewResult) string {
 				if f.Line > 0 {
 					location = fmt.Sprintf("%s:%d", f.File, f.Line)
 				}
-				emoji := severityEmoji(sev)
+				emoji := SeverityEmoji(sev)
 				sb.WriteString(fmt.Sprintf("<details>\n<summary>%s <strong>%s</strong> &nbsp;<code>%s</code></summary>\n\n",
 					emoji, sanitizeTableCell(f.Title), sanitizeInlineCode(location)))
 				sb.WriteString(fmt.Sprintf("**Category:** `%s` &nbsp;·&nbsp; **Severity:** %s\n\n", f.Category, severityLabel(sev)))
@@ -183,7 +183,8 @@ func (m *MarkdownOutput) RenderSummary(result *model.ReviewResult) string {
 	return sb.String()
 }
 
-func severityEmoji(s model.Severity) string {
+// SeverityEmoji returns the colored circle emoji for a severity level.
+func SeverityEmoji(s model.Severity) string {
 	switch s {
 	case model.SeverityCritical:
 		return "🔴"
@@ -269,13 +270,17 @@ func SanitizeHTML(v string) string {
 }
 
 // RenderAgentSuggestion formats a finding suggestion as a markdown agent fix prompt block.
-// Returns an empty string if the suggestion is empty. Callers are responsible for
-// surrounding whitespace/newlines.
+// The suggestion is rendered inside a fenced code block to display as literal text,
+// preventing any markdown/HTML interpretation. Returns an empty string if the suggestion
+// is empty. Callers are responsible for surrounding whitespace/newlines.
 func RenderAgentSuggestion(suggestion string) string {
 	if suggestion == "" {
 		return ""
 	}
-	return fmt.Sprintf("**🤖 Agent fix prompt:**\n> %s", SanitizeBlockquote(suggestion))
+	// Use a fenced code block so suggestion text is rendered literally,
+	// immune to markdown metacharacters, HTML, and blockquote nesting.
+	sanitized := strings.ReplaceAll(suggestion, "```", "` ` `")
+	return fmt.Sprintf("**🤖 Agent fix prompt:**\n```text\n%s\n```", sanitized)
 }
 
 func vibeBar(score int) string {

--- a/internal/output/markdown_test.go
+++ b/internal/output/markdown_test.go
@@ -79,6 +79,58 @@ func TestRenderSummary_NoSuggestionOmitsAgentPrompt(t *testing.T) {
 	}
 }
 
+func TestRenderSummary_SuggestionWithSpecialCharsIsEscaped(t *testing.T) {
+	out := NewMarkdownOutput("SURGE")
+	result := &model.ReviewResult{
+		Summary: "Test escaping.",
+		Findings: []model.Finding{
+			{
+				Severity:   model.SeverityHigh,
+				Category:   model.CategorySecurity,
+				File:       "main.go",
+				Line:       1,
+				Title:      "Test finding",
+				Body:       "Body text.",
+				Suggestion: "Fix <script>alert('xss')</script>\n> nested quote\nline two",
+			},
+		},
+		VibeCheck: model.VibeCheck{Score: 5, Verdict: "Okay"},
+		Approve:   false,
+		Stats:     model.ReviewStats{FilesReviewed: 1},
+	}
+
+	rendered := out.RenderSummary(result)
+
+	// HTML tags must be escaped
+	assertContains(t, rendered, "&lt;script&gt;")
+	assertContains(t, rendered, "&lt;/script&gt;")
+	// Newlines collapsed, no nested blockquotes
+	if strings.Contains(rendered, "\n> nested") {
+		t.Fatal("newlines in suggestion should be collapsed to prevent nested blockquotes")
+	}
+	// The > inside the suggestion text should be escaped
+	assertContains(t, rendered, "&gt; nested quote")
+}
+
+func TestSanitizeBlockquote(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"simple text", "simple text"},
+		{"line1\nline2", "line1 line2"},
+		{"<b>bold</b>", "&lt;b&gt;bold&lt;/b&gt;"},
+		{"> nested quote", "&gt; nested quote"},
+		{"  spaces  ", "spaces"},
+	}
+	for _, tt := range tests {
+		got := SanitizeBlockquote(tt.input)
+		if got != tt.want {
+			t.Errorf("SanitizeBlockquote(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
 func assertContains(t *testing.T, text, want string) {
 	t.Helper()
 	if !strings.Contains(text, want) {

--- a/internal/output/markdown_test.go
+++ b/internal/output/markdown_test.go
@@ -112,6 +112,70 @@ func TestRenderSummary_SuggestionWithSpecialCharsIsEscaped(t *testing.T) {
 	assertContains(t, rendered, "&gt; nested quote")
 }
 
+func TestSanitizeHTML(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"plain text", "plain text"},
+		{"<script>alert('x')</script>", "&lt;script&gt;alert('x')&lt;/script&gt;"},
+		{"a > b && c < d", "a &gt; b && c &lt; d"},
+		{"line1\nline2", "line1\nline2"}, // preserves newlines
+	}
+	for _, tt := range tests {
+		got := SanitizeHTML(tt.input)
+		if got != tt.want {
+			t.Errorf("SanitizeHTML(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestRenderAgentSuggestion(t *testing.T) {
+	// Empty suggestion returns empty string
+	if got := RenderAgentSuggestion(""); got != "" {
+		t.Errorf("RenderAgentSuggestion(\"\") = %q, want empty", got)
+	}
+
+	got := RenderAgentSuggestion("Fix <the> bug\nin two lines")
+	assertContains(t, got, "🤖 Agent fix prompt:")
+	assertContains(t, got, "&lt;the&gt;")
+	// Newlines should be collapsed
+	if strings.Contains(got, "\n> in two") {
+		t.Fatal("newlines should be collapsed in suggestion blockquote")
+	}
+}
+
+func TestRenderSummary_SanitizesModelFields(t *testing.T) {
+	out := NewMarkdownOutput("SURGE")
+	result := &model.ReviewResult{
+		Summary: "Summary with <img src=x onerror=alert(1)> injection",
+		Findings: []model.Finding{
+			{
+				Severity: model.SeverityLow,
+				Category: model.CategoryLogic,
+				File:     "main.go",
+				Title:    "Title is clean",
+				Body:     "Body with <script>bad</script> HTML",
+			},
+		},
+		VibeCheck: model.VibeCheck{
+			Score:   7,
+			Verdict: "Verdict <b>bold</b>",
+		},
+		Recommendations: []string{"Step with <a href=x>link</a>"},
+		Approve:         true,
+		Stats:           model.ReviewStats{FilesReviewed: 1},
+	}
+
+	rendered := out.RenderSummary(result)
+
+	// All HTML should be escaped
+	assertContains(t, rendered, "&lt;img src=x onerror=alert(1)&gt;")
+	assertContains(t, rendered, "&lt;script&gt;bad&lt;/script&gt;")
+	assertContains(t, rendered, "&lt;b&gt;bold&lt;/b&gt;")
+	assertContains(t, rendered, "&lt;a href=x&gt;link&lt;/a&gt;")
+}
+
 func TestSanitizeBlockquote(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/output/markdown_test.go
+++ b/internal/output/markdown_test.go
@@ -112,6 +112,20 @@ func TestRenderSummary_SuggestionWithSpecialCharsIsEscaped(t *testing.T) {
 	assertContains(t, rendered, "&gt; nested quote")
 }
 
+func TestRenderSummary_ZeroFindingsShowsBadgeLine(t *testing.T) {
+	out := NewMarkdownOutput("SURGE")
+	result := &model.ReviewResult{
+		Summary:   "All good.",
+		Findings:  nil,
+		VibeCheck: model.VibeCheck{Score: 10, Verdict: "Perfect"},
+		Approve:   true,
+		Stats:     model.ReviewStats{FilesReviewed: 2},
+	}
+
+	rendered := out.RenderSummary(result)
+	assertContains(t, rendered, "⚪ 0 findings")
+}
+
 func TestSanitizeHTML(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/output/markdown_test.go
+++ b/internal/output/markdown_test.go
@@ -16,12 +16,13 @@ func TestRenderSummary_ModernLayoutIncludesCoreSections(t *testing.T) {
 		},
 		Findings: []model.Finding{
 			{
-				Severity: model.SeverityHigh,
-				Category: model.CategorySecurity,
-				File:     "internal/auth/session.go",
-				Line:     42,
-				Title:    "Refresh token can be replayed",
-				Body:     "Rotate refresh tokens after use to prevent replay.",
+				Severity:   model.SeverityHigh,
+				Category:   model.CategorySecurity,
+				File:       "internal/auth/session.go",
+				Line:       42,
+				Title:      "Refresh token can be replayed",
+				Body:       "Rotate refresh tokens after use to prevent replay.",
+				Suggestion: "In handleTokenRefresh(), generate a new refresh token after each use and invalidate the previous one.",
 			},
 		},
 		VibeCheck: model.VibeCheck{
@@ -39,17 +40,43 @@ func TestRenderSummary_ModernLayoutIncludesCoreSections(t *testing.T) {
 	rendered := out.RenderSummary(result)
 
 	assertContains(t, rendered, "<!-- SURGE -->")
-	assertContains(t, rendered, "## ⚡ surge Review Summary")
-	assertContains(t, rendered, "### Severity Rollup")
-	assertContains(t, rendered, "## 🧭 Findings")
-	assertContains(t, rendered, "### 🟠 HIGH (1)")
-	assertContains(t, rendered, "<summary><strong>Refresh token can be replayed</strong>")
+	assertContains(t, rendered, "## ⚡ surge")
+	assertContains(t, rendered, "Changes Requested")
+	assertContains(t, rendered, "### Findings")
+	assertContains(t, rendered, "🟠")
+	assertContains(t, rendered, "<strong>Refresh token can be replayed</strong>")
 	assertContains(t, rendered, "<code>internal/auth/session.go:42</code>")
-	assertContains(t, rendered, "## 🎯 Vibe Check")
-	assertContains(t, rendered, "**Score:** 8/10")
+	assertContains(t, rendered, "🎯 Vibe Check")
+	assertContains(t, rendered, "8/10")
 	assertContains(t, rendered, "████████░░")
-	assertContains(t, rendered, "## ✅ Recommended Next Steps")
+	assertContains(t, rendered, "Recommended next steps")
 	assertContains(t, rendered, "- [ ] Add replay protection test")
+	assertContains(t, rendered, "🤖 Agent fix prompt:")
+	assertContains(t, rendered, "generate a new refresh token")
+}
+
+func TestRenderSummary_NoSuggestionOmitsAgentPrompt(t *testing.T) {
+	out := NewMarkdownOutput("SURGE")
+	result := &model.ReviewResult{
+		Summary: "Minor style fixes.",
+		Findings: []model.Finding{
+			{
+				Severity: model.SeverityLow,
+				Category: model.CategoryMaintainability,
+				File:     "main.go",
+				Title:    "Unused import",
+				Body:     "Remove unused import.",
+			},
+		},
+		VibeCheck: model.VibeCheck{Score: 9, Verdict: "Clean"},
+		Approve:   true,
+		Stats:     model.ReviewStats{FilesReviewed: 1},
+	}
+
+	rendered := out.RenderSummary(result)
+	if strings.Contains(rendered, "Agent fix prompt") {
+		t.Fatal("expected no agent fix prompt when suggestion is empty")
+	}
 }
 
 func assertContains(t *testing.T, text, want string) {

--- a/internal/output/markdown_test.go
+++ b/internal/output/markdown_test.go
@@ -101,15 +101,11 @@ func TestRenderSummary_SuggestionWithSpecialCharsIsEscaped(t *testing.T) {
 
 	rendered := out.RenderSummary(result)
 
-	// HTML tags must be escaped
-	assertContains(t, rendered, "&lt;script&gt;")
-	assertContains(t, rendered, "&lt;/script&gt;")
-	// Newlines collapsed, no nested blockquotes
-	if strings.Contains(rendered, "\n> nested") {
-		t.Fatal("newlines in suggestion should be collapsed to prevent nested blockquotes")
-	}
-	// The > inside the suggestion text should be escaped
-	assertContains(t, rendered, "&gt; nested quote")
+	// Suggestion should be inside a code fence
+	assertContains(t, rendered, "```text")
+	assertContains(t, rendered, "🤖 Agent fix prompt:")
+	// Content is literal inside code fence — raw text preserved
+	assertContains(t, rendered, "Fix <script>alert('xss')</script>")
 }
 
 func TestRenderSummary_ZeroFindingsShowsBadgeLine(t *testing.T) {
@@ -152,10 +148,14 @@ func TestRenderAgentSuggestion(t *testing.T) {
 
 	got := RenderAgentSuggestion("Fix <the> bug\nin two lines")
 	assertContains(t, got, "🤖 Agent fix prompt:")
-	assertContains(t, got, "&lt;the&gt;")
-	// Newlines should be collapsed
-	if strings.Contains(got, "\n> in two") {
-		t.Fatal("newlines should be collapsed in suggestion blockquote")
+	assertContains(t, got, "```text")
+	assertContains(t, got, "Fix <the> bug")
+	// Content should be inside a code fence, preserving literal text
+
+	// Triple backticks in suggestion should be escaped
+	got2 := RenderAgentSuggestion("Use ```code``` here")
+	if strings.Contains(got2, "```code```") {
+		t.Fatal("triple backticks in suggestion should be escaped to prevent breaking the code fence")
 	}
 }
 

--- a/internal/output/terminal.go
+++ b/internal/output/terminal.go
@@ -80,6 +80,10 @@ func (t *TerminalOutput) Render(result *model.ReviewResult) {
 				for _, line := range bodyLines {
 					fmt.Printf("    %s\n", line)
 				}
+				if f.Suggestion != "" {
+					fixStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#00CED1")).Italic(true)
+					fmt.Printf("    %s\n", fixStyle.Render("Fix: "+f.Suggestion))
+				}
 				fmt.Println()
 			}
 		}

--- a/internal/output/terminal.go
+++ b/internal/output/terminal.go
@@ -82,7 +82,7 @@ func (t *TerminalOutput) Render(result *model.ReviewResult) {
 				}
 				if f.Suggestion != "" {
 					fixStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#00CED1")).Italic(true)
-					fmt.Printf("    %s\n", fixStyle.Render("Fix: "+f.Suggestion))
+					fmt.Printf("    %s\n", fixStyle.Render("Fix: "+sanitizeTerminalText(f.Suggestion)))
 				}
 				fmt.Println()
 			}
@@ -183,6 +183,37 @@ func wrapText(text string, width int) []string {
 	}
 
 	return lines
+}
+
+// sanitizeTerminalText strips ANSI escape sequences and control characters
+// from untrusted text to prevent terminal injection.
+func sanitizeTerminalText(v string) string {
+	var sb strings.Builder
+	sb.Grow(len(v))
+	i := 0
+	for i < len(v) {
+		b := v[i]
+		// Strip ANSI escape sequences (ESC [ ... final byte)
+		if b == 0x1b && i+1 < len(v) && v[i+1] == '[' {
+			i += 2
+			for i < len(v) && v[i] >= 0x20 && v[i] <= 0x3F {
+				i++
+			}
+			if i < len(v) {
+				i++ // skip final byte
+			}
+			continue
+		}
+		// Replace control characters (except space) with space
+		if b < 0x20 && b != '\n' {
+			sb.WriteByte(' ')
+		} else {
+			sb.WriteByte(b)
+		}
+		i++
+	}
+	// Collapse newlines to spaces for single-line display
+	return strings.ReplaceAll(sb.String(), "\n", " ")
 }
 
 // RenderError prints an error message to stderr.

--- a/internal/review/orchestrator.go
+++ b/internal/review/orchestrator.go
@@ -357,7 +357,7 @@ func (o *Orchestrator) buildInlineComments(result *model.ReviewResult, files []m
 			finding.Body,
 		)
 		if finding.Suggestion != "" {
-			body += fmt.Sprintf("\n\n**🤖 Agent fix prompt:**\n> %s", finding.Suggestion)
+			body += fmt.Sprintf("\n\n**🤖 Agent fix prompt:**\n> %s", output.SanitizeBlockquote(finding.Suggestion))
 		}
 
 		comments = append(comments, model.ReviewComment{

--- a/internal/review/orchestrator.go
+++ b/internal/review/orchestrator.go
@@ -348,11 +348,11 @@ func (o *Orchestrator) buildInlineComments(result *model.ReviewResult, files []m
 			continue
 		}
 
-		emoji := severityEmojiForInline(finding.Severity)
+		emoji := output.SeverityEmoji(finding.Severity)
 		body := fmt.Sprintf("%s **%s** — %s\n\n%s",
 			emoji,
 			output.SanitizeHTML(finding.Title),
-			strings.ToUpper(string(finding.Severity)),
+			output.SanitizeHTML(strings.ToUpper(string(finding.Severity))),
 			output.SanitizeHTML(finding.Body),
 		)
 		if suggestion := output.RenderAgentSuggestion(finding.Suggestion); suggestion != "" {
@@ -453,21 +453,6 @@ func (o *Orchestrator) isSurgeComment(body string) bool {
 		}
 	}
 	return strings.Contains(body, "<!-- SURGE_SUMMARY -->")
-}
-
-func severityEmojiForInline(s model.Severity) string {
-	switch s {
-	case model.SeverityCritical:
-		return "🔴"
-	case model.SeverityHigh:
-		return "🟠"
-	case model.SeverityMedium:
-		return "🟡"
-	case model.SeverityLow:
-		return "🔵"
-	default:
-		return "⚪"
-	}
 }
 
 // findPositionInPatch finds the diff position for a given file line number.

--- a/internal/review/orchestrator.go
+++ b/internal/review/orchestrator.go
@@ -348,17 +348,14 @@ func (o *Orchestrator) buildInlineComments(result *model.ReviewResult, files []m
 			continue
 		}
 
-		var body string
 		emoji := severityEmojiForInline(finding.Severity)
-		body = fmt.Sprintf("%s **%s** — %s\n\n%s",
+		body := fmt.Sprintf("%s **%s** — %s\n\n%s",
 			emoji,
-			finding.Title,
+			output.SanitizeHTML(finding.Title),
 			strings.ToUpper(string(finding.Severity)),
-			finding.Body,
+			output.SanitizeHTML(finding.Body),
 		)
-		if finding.Suggestion != "" {
-			body += fmt.Sprintf("\n\n**🤖 Agent fix prompt:**\n> %s", output.SanitizeBlockquote(finding.Suggestion))
-		}
+		body += output.RenderAgentSuggestion(finding.Suggestion)
 
 		comments = append(comments, model.ReviewComment{
 			Path:     finding.File,

--- a/internal/review/orchestrator.go
+++ b/internal/review/orchestrator.go
@@ -355,7 +355,9 @@ func (o *Orchestrator) buildInlineComments(result *model.ReviewResult, files []m
 			strings.ToUpper(string(finding.Severity)),
 			output.SanitizeHTML(finding.Body),
 		)
-		body += output.RenderAgentSuggestion(finding.Suggestion)
+		if suggestion := output.RenderAgentSuggestion(finding.Suggestion); suggestion != "" {
+			body += "\n\n" + suggestion
+		}
 
 		comments = append(comments, model.ReviewComment{
 			Path:     finding.File,

--- a/internal/review/orchestrator.go
+++ b/internal/review/orchestrator.go
@@ -348,11 +348,17 @@ func (o *Orchestrator) buildInlineComments(result *model.ReviewResult, files []m
 			continue
 		}
 
-		body := fmt.Sprintf("**%s** %s\n\n%s",
-			strings.ToUpper(string(finding.Severity)),
+		var body string
+		emoji := severityEmojiForInline(finding.Severity)
+		body = fmt.Sprintf("%s **%s** — %s\n\n%s",
+			emoji,
 			finding.Title,
+			strings.ToUpper(string(finding.Severity)),
 			finding.Body,
 		)
+		if finding.Suggestion != "" {
+			body += fmt.Sprintf("\n\n**🤖 Agent fix prompt:**\n> %s", finding.Suggestion)
+		}
 
 		comments = append(comments, model.ReviewComment{
 			Path:     finding.File,
@@ -448,6 +454,21 @@ func (o *Orchestrator) isSurgeComment(body string) bool {
 		}
 	}
 	return strings.Contains(body, "<!-- SURGE_SUMMARY -->")
+}
+
+func severityEmojiForInline(s model.Severity) string {
+	switch s {
+	case model.SeverityCritical:
+		return "🔴"
+	case model.SeverityHigh:
+		return "🟠"
+	case model.SeverityMedium:
+		return "🟡"
+	case model.SeverityLow:
+		return "🔵"
+	default:
+		return "⚪"
+	}
 }
 
 // findPositionInPatch finds the diff position for a given file line number.

--- a/internal/review/orchestrator_test.go
+++ b/internal/review/orchestrator_test.go
@@ -452,6 +452,47 @@ func TestFormatContextWarnings(t *testing.T) {
 	assert.Equal(t, "Skip reasons: a.go (not found), b.go (permission denied).", warnings[1])
 }
 
+func TestBuildInlineCommentsWithSuggestion(t *testing.T) {
+	cfg := &config.Config{CommentMarker: "SURGE"}
+	o := NewOrchestrator(nil, &stubPRClient{}, cfg)
+
+	result := &model.ReviewResult{
+		Findings: []model.Finding{
+			{
+				Severity:   model.SeverityHigh,
+				File:       "main.go",
+				Line:       2,
+				Title:      "SQL injection <script>",
+				Body:       "User input is <b>unsanitized</b>",
+				Suggestion: "Parameterize the query in `handler()` to prevent injection.",
+			},
+			{
+				Severity: model.SeverityLow,
+				File:     "main.go",
+				Line:     2,
+				Title:    "No suggestion finding",
+				Body:     "Minor style issue.",
+			},
+		},
+	}
+	files := []model.FileChange{
+		{Path: "main.go", Patch: "@@ -1,2 +1,2 @@\n line1\n+line2"},
+	}
+
+	comments := o.buildInlineComments(result, files)
+	require.Len(t, comments, 2)
+
+	// First comment: has suggestion, HTML escaped
+	assert.Contains(t, comments[0].Body, "🟠")
+	assert.Contains(t, comments[0].Body, "&lt;script&gt;")
+	assert.Contains(t, comments[0].Body, "&lt;b&gt;unsanitized&lt;/b&gt;")
+	assert.Contains(t, comments[0].Body, "🤖 Agent fix prompt:")
+	assert.Contains(t, comments[0].Body, "Parameterize the query")
+
+	// Second comment: no suggestion block
+	assert.NotContains(t, comments[1].Body, "Agent fix prompt")
+}
+
 func TestSanitizeContextWarningReason(t *testing.T) {
 	assert.Equal(t, "not found", sanitizeContextWarningReason(errors.New("file not found")))
 	assert.Equal(t, "permission denied", sanitizeContextWarningReason(errors.New("forbidden by policy")))

--- a/internal/review/prompts.go
+++ b/internal/review/prompts.go
@@ -83,7 +83,7 @@ text before or after the JSON. The JSON schema is:
       "line": 42,
       "title": "Brief finding title",
       "body": "Detailed explanation (markdown supported, 1-3 sentences)",
-      "suggestion": "A concise, actionable instruction for an AI coding agent to fix this issue. Write it as a direct command, e.g. 'Rotate the refresh token after each use in handleTokenRefresh() by generating a new token and invalidating the old one.' Include the specific function/file, what to change, and why."
+      "suggestion": "(optional) A concise, actionable instruction for an AI coding agent to fix this issue. Write it as a direct command, e.g. 'Rotate the refresh token after each use in handleTokenRefresh() by generating a new token and invalidating the old one.' Include the specific function/file, what to change, and why. Omit this field for info-level findings or when no concrete fix applies."
     }
   ],
   "vibeCheck": {

--- a/internal/review/prompts.go
+++ b/internal/review/prompts.go
@@ -82,7 +82,8 @@ text before or after the JSON. The JSON schema is:
       "file": "relative/path/to/file.ext",
       "line": 42,
       "title": "Brief finding title",
-      "body": "Detailed explanation (markdown supported, 1-3 sentences)"
+      "body": "Detailed explanation (markdown supported, 1-3 sentences)",
+      "suggestion": "A concise, actionable instruction for an AI coding agent to fix this issue. Write it as a direct command, e.g. 'Rotate the refresh token after each use in handleTokenRefresh() by generating a new token and invalidating the old one.' Include the specific function/file, what to change, and why."
     }
   ],
   "vibeCheck": {


### PR DESCRIPTION
## Summary

- Adds a `suggestion` field to each finding — a concise, actionable prompt that an AI coding agent can copy-paste to fix the issue
- Redesigns the GitHub markdown review comment to be cleaner and less overwhelming: compact header with inline severity badges, collapsible sections for vibe check and recommendations, and streamlined finding cards
- Includes the agent fix prompt in both summary comments and inline review comments

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New test verifies agent fix prompt appears when suggestion is present
- [x] New test verifies agent fix prompt is omitted when suggestion is empty
- [ ] Run `surge review --pr N --dry-run` on a real PR to verify the new layout renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)