### PR TITLE
test: reach 100% coverage and add README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # surge
 
-[![Go Version](https://img.shields.io/badge/Go-1.26+-00ADD8?logo=go&logoColor=white)](https://go.dev/)
+[![Go Version](https://img.shields.io/badge/Go-1.26-00ADD8?logo=go&logoColor=white)](https://go.dev/)
 [![Coverage](https://img.shields.io/badge/Coverage-100%25-2da44e)](#)
 [![Tests](https://img.shields.io/badge/Tests-passing-2da44e)](#)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # surge
 
+[![Go Version](https://img.shields.io/badge/Go-1.26+-00ADD8?logo=go&logoColor=white)](https://go.dev/)
+[![Coverage](https://img.shields.io/badge/Coverage-100%25-2da44e)](#)
+[![Tests](https://img.shields.io/badge/Tests-passing-2da44e)](#)
+
 AI-powered PR code review with style.
 
 `surge` analyzes your pull request diffs and provides structured, actionable feedback on security vulnerabilities, performance issues, logic bugs, code quality, and something special we call **vibe codability** -- detecting AI-generated code that is technically correct but soulless.

--- a/cmd/surge/main_test.go
+++ b/cmd/surge/main_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitAndMainSuccess(t *testing.T) {
+	oldArgs := os.Args
+	t.Cleanup(func() { os.Args = oldArgs })
+	os.Args = []string{"surge", "--help"}
+
+	stdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	main()
+
+	require.NoError(t, w.Close())
+	os.Stdout = stdout
+
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	assert.Contains(t, buf.String(), "surge is an AI-powered code review tool for pull requests.")
+}
+
+func TestMainErrorExit(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestMainErrorHelper", "--", "unknown")
+	cmd.Env = append(os.Environ(), "SURGE_MAIN_ERROR_HELPER=1")
+	output, err := cmd.CombinedOutput()
+	require.Error(t, err)
+	assert.Contains(t, string(output), "error: unknown command")
+}
+
+func TestMainErrorHelper(t *testing.T) {
+	if os.Getenv("SURGE_MAIN_ERROR_HELPER") != "1" {
+		return
+	}
+	os.Args = []string{"surge", "unknown"}
+	main()
+}

--- a/internal/ai/claude.go
+++ b/internal/ai/claude.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 )
 
+var claudeMarshal = json.Marshal
+
 // ClaudeClient implements AIClient for the Anthropic Claude API.
 type ClaudeClient struct {
 	apiKey  string
@@ -48,8 +50,8 @@ func (c *ClaudeClient) Complete(ctx context.Context, req *CompletionRequest) (*C
 	}
 
 	payload := map[string]interface{}{
-		"model":    c.model,
-		"messages":  messages,
+		"model":      c.model,
+		"messages":   messages,
 		"max_tokens": req.MaxTokens,
 	}
 
@@ -57,7 +59,7 @@ func (c *ClaudeClient) Complete(ctx context.Context, req *CompletionRequest) (*C
 		payload["temperature"] = req.Temperature
 	}
 
-	body, err := json.Marshal(payload)
+	body, err := claudeMarshal(payload)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}

--- a/internal/ai/claude_test.go
+++ b/internal/ai/claude_test.go
@@ -1,0 +1,178 @@
+package ai
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type errReadCloser struct{}
+
+func (errReadCloser) Read([]byte) (int, error) { return 0, errors.New("read failed") }
+func (errReadCloser) Close() error             { return nil }
+
+func TestClaudeClientComplete(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		var gotAPIKey string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAPIKey = r.Header.Get("x-api-key")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"content":[{"type":"text","text":"Hello "},{"type":"tool","text":"ignored"},{"type":"text","text":"world"}],
+				"usage":{"input_tokens":7,"output_tokens":3},
+				"stop_reason":"end_turn"
+			}`))
+		}))
+		defer server.Close()
+
+		client := NewClaudeClient("test-key", "claude-test")
+		client.baseURL = server.URL
+		client.client = server.Client()
+
+		resp, err := client.Complete(context.Background(), &CompletionRequest{
+			System:      "system",
+			Messages:    []Message{{Role: "user", Content: "hi"}},
+			MaxTokens:   55,
+			Temperature: 0.2,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "Hello world", resp.Content)
+		assert.Equal(t, 7, resp.TokensIn)
+		assert.Equal(t, 3, resp.TokensOut)
+		assert.Equal(t, "end_turn", resp.FinishReason)
+		assert.Equal(t, "test-key", gotAPIKey)
+		assert.Equal(t, "claude", client.Name())
+	})
+
+	t.Run("api error json", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"type":"bad_request","message":"nope"}}`))
+		}))
+		defer server.Close()
+
+		client := NewClaudeClient("test-key", "claude-test")
+		client.baseURL = server.URL
+		client.client = server.Client()
+
+		_, err := client.Complete(context.Background(), &CompletionRequest{MaxTokens: 1, Debug: true})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "claude API error (400 Bad Request): nope")
+	})
+
+	t.Run("api error raw body", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte(`boom`))
+		}))
+		defer server.Close()
+
+		client := NewClaudeClient("test-key", "claude-test")
+		client.baseURL = server.URL
+		client.client = server.Client()
+
+		_, err := client.Complete(context.Background(), &CompletionRequest{MaxTokens: 1})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "claude API error (502 Bad Gateway): boom")
+	})
+
+	t.Run("parse error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{`))
+		}))
+		defer server.Close()
+
+		client := NewClaudeClient("test-key", "claude-test")
+		client.baseURL = server.URL
+		client.client = server.Client()
+
+		_, err := client.Complete(context.Background(), &CompletionRequest{MaxTokens: 1})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed to parse claude response")
+	})
+}
+
+func TestClaudeClientTransportErrors(t *testing.T) {
+	client := NewClaudeClient("test-key", "claude-test")
+	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("network down")
+	})}
+
+	_, err := client.Complete(context.Background(), &CompletionRequest{MaxTokens: 1})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "claude request failed: Post")
+
+	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       errReadCloser{},
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	_, err = client.Complete(context.Background(), &CompletionRequest{MaxTokens: 1})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to read response")
+
+	client.baseURL = "://bad"
+	client.client = &http.Client{}
+	_, err = client.Complete(context.Background(), &CompletionRequest{MaxTokens: 1})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to create request")
+}
+
+func TestClaudeDebugOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"ok"}],"usage":{"input_tokens":1,"output_tokens":1},"stop_reason":"done"}`))
+	}))
+	defer server.Close()
+
+	client := NewClaudeClient("test-key", "claude-test")
+	client.baseURL = server.URL
+	client.client = server.Client()
+
+	stderr := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+
+	_, err = client.Complete(context.Background(), &CompletionRequest{MaxTokens: 1, Debug: true})
+	require.NoError(t, err)
+
+	require.NoError(t, w.Close())
+	os.Stderr = stderr
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	assert.Contains(t, buf.String(), "[debug] claude request")
+	assert.Contains(t, buf.String(), "[debug] claude response status=200 OK")
+}
+
+func TestClaudeMarshalError(t *testing.T) {
+	prev := claudeMarshal
+	claudeMarshal = func(v interface{}) ([]byte, error) { return nil, errors.New("marshal failed") }
+	t.Cleanup(func() { claudeMarshal = prev })
+
+	client := NewClaudeClient("test-key", "claude-test")
+	_, err := client.Complete(context.Background(), &CompletionRequest{MaxTokens: 1})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to marshal request")
+}

--- a/internal/ai/litellm.go
+++ b/internal/ai/litellm.go
@@ -13,17 +13,15 @@ import (
 	"strings"
 )
 
-var (
-	chatCompletionURLCandidates = candidateChatCompletionURLs
-	responsesURLCandidates      = candidateResponsesURLs
-)
-
 // LiteLLMClient implements AIClient for litellm proxies (OpenAI-compatible API).
 type LiteLLMClient struct {
 	baseURL string
 	apiKey  string
 	model   string
 	client  *http.Client
+
+	chatCompletionURLCandidates func(base string) []string
+	responsesURLCandidates      func(base string) []string
 }
 
 // NewLiteLLMClient creates a new litellm client.
@@ -33,6 +31,9 @@ func NewLiteLLMClient(baseURL, apiKey, model string) *LiteLLMClient {
 		apiKey:  apiKey,
 		model:   model,
 		client:  &http.Client{Timeout: 120 * 1e9}, // 120 seconds
+
+		chatCompletionURLCandidates: candidateChatCompletionURLs,
+		responsesURLCandidates:      candidateResponsesURLs,
 	}
 }
 
@@ -62,7 +63,7 @@ func (c *LiteLLMClient) completeChatCompletions(ctx context.Context, req *Comple
 		messages = append(messages, map[string]string{"role": m.Role, "content": m.Content})
 	}
 
-	urls := chatCompletionURLCandidates(c.baseURL)
+	urls := c.chatCompletionURLCandidates(c.baseURL)
 	tokenFields := []string{"max_tokens", "max_completion_tokens"}
 	var lastErr error
 
@@ -151,7 +152,7 @@ func parseChatCompletionsResponse(respBody []byte) (*CompletionResponse, error) 
 }
 
 func (c *LiteLLMClient) completeResponses(ctx context.Context, req *CompletionRequest) (*CompletionResponse, error) {
-	urls := responsesURLCandidates(c.baseURL)
+	urls := c.responsesURLCandidates(c.baseURL)
 	tokenFields := []string{"max_output_tokens", "max_tokens", "max_completion_tokens", ""}
 	var lastErr error
 

--- a/internal/ai/litellm.go
+++ b/internal/ai/litellm.go
@@ -1,8 +1,8 @@
 package ai
 
 import (
-	"bytes"
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -11,6 +11,11 @@ import (
 	"net/http"
 	"os"
 	"strings"
+)
+
+var (
+	chatCompletionURLCandidates = candidateChatCompletionURLs
+	responsesURLCandidates      = candidateResponsesURLs
 )
 
 // LiteLLMClient implements AIClient for litellm proxies (OpenAI-compatible API).
@@ -57,7 +62,7 @@ func (c *LiteLLMClient) completeChatCompletions(ctx context.Context, req *Comple
 		messages = append(messages, map[string]string{"role": m.Role, "content": m.Content})
 	}
 
-	urls := candidateChatCompletionURLs(c.baseURL)
+	urls := chatCompletionURLCandidates(c.baseURL)
 	tokenFields := []string{"max_tokens", "max_completion_tokens"}
 	var lastErr error
 
@@ -123,7 +128,7 @@ func parseChatCompletionsResponse(respBody []byte) (*CompletionResponse, error) 
 		Usage struct {
 			PromptTokens     int `json:"prompt_tokens"`
 			CompletionTokens int `json:"completion_tokens"`
-			TotalTokens     int `json:"total_tokens"`
+			TotalTokens      int `json:"total_tokens"`
 		} `json:"usage"`
 		Model string `json:"model"`
 	}
@@ -146,7 +151,7 @@ func parseChatCompletionsResponse(respBody []byte) (*CompletionResponse, error) 
 }
 
 func (c *LiteLLMClient) completeResponses(ctx context.Context, req *CompletionRequest) (*CompletionResponse, error) {
-	urls := candidateResponsesURLs(c.baseURL)
+	urls := responsesURLCandidates(c.baseURL)
 	tokenFields := []string{"max_output_tokens", "max_tokens", "max_completion_tokens", ""}
 	var lastErr error
 
@@ -157,71 +162,71 @@ func (c *LiteLLMClient) completeResponses(ctx context.Context, req *CompletionRe
 				includeTemperatureOptions = []bool{true, false}
 			}
 			for _, includeTemperature := range includeTemperatureOptions {
-			debugTokenField := tokenField
-			if debugTokenField == "" {
-				debugTokenField = "<none>"
-			}
-			if req.Debug {
-				tempLabel := "<none>"
-				if includeTemperature {
-					tempLabel = fmt.Sprintf("%.2f", req.Temperature)
+				debugTokenField := tokenField
+				if debugTokenField == "" {
+					debugTokenField = "<none>"
 				}
-				fmt.Fprintf(os.Stderr, "[debug] litellm responses request url=%s model=%s token_field=%s max_tokens=%d temperature=%s\n",
-					url, req.Model, debugTokenField, req.MaxTokens, tempLabel)
-			}
-
-			payload := map[string]interface{}{
-				"model":        req.Model,
-				"instructions": req.System,
-				"input":        responsesInputFromMessages(req.Messages),
-				"stream":       true,
-			}
-			if tokenField != "" {
-				payload[tokenField] = req.MaxTokens
-			}
-			if includeTemperature && req.Temperature > 0 {
-				payload["temperature"] = req.Temperature
-			}
-
-			respBody, status, err := c.doJSONPost(ctx, url, payload)
-			if err != nil {
-				lastErr = fmt.Errorf("litellm responses request failed: %w", err)
-				continue
-			}
-			if status == http.StatusOK {
 				if req.Debug {
-					fmt.Fprintf(os.Stderr, "[debug] litellm responses status=%d\n", status)
+					tempLabel := "<none>"
+					if includeTemperature {
+						tempLabel = fmt.Sprintf("%.2f", req.Temperature)
+					}
+					fmt.Fprintf(os.Stderr, "[debug] litellm responses request url=%s model=%s token_field=%s max_tokens=%d temperature=%s\n",
+						url, req.Model, debugTokenField, req.MaxTokens, tempLabel)
 				}
-				content, tokensIn, tokensOut, finishReason, err := parseResponsesSSE(respBody)
-				if err != nil {
-					return nil, fmt.Errorf("failed to parse litellm responses stream: %w", err)
-				}
-				return &CompletionResponse{
-					Content:      content,
-					Model:        req.Model,
-					TokensIn:     tokensIn,
-					TokensOut:    tokensOut,
-					FinishReason: finishReason,
-				}, nil
-			}
 
-			if req.Debug {
-				fmt.Fprintf(os.Stderr, "[debug] litellm responses status=%d body=%s\n", status, strings.TrimSpace(string(respBody)))
+				payload := map[string]interface{}{
+					"model":        req.Model,
+					"instructions": req.System,
+					"input":        responsesInputFromMessages(req.Messages),
+					"stream":       true,
+				}
+				if tokenField != "" {
+					payload[tokenField] = req.MaxTokens
+				}
+				if includeTemperature && req.Temperature > 0 {
+					payload["temperature"] = req.Temperature
+				}
+
+				respBody, status, err := c.doJSONPost(ctx, url, payload)
+				if err != nil {
+					lastErr = fmt.Errorf("litellm responses request failed: %w", err)
+					continue
+				}
+				if status == http.StatusOK {
+					if req.Debug {
+						fmt.Fprintf(os.Stderr, "[debug] litellm responses status=%d\n", status)
+					}
+					content, tokensIn, tokensOut, finishReason, err := parseResponsesSSE(respBody)
+					if err != nil {
+						return nil, fmt.Errorf("failed to parse litellm responses stream: %w", err)
+					}
+					return &CompletionResponse{
+						Content:      content,
+						Model:        req.Model,
+						TokensIn:     tokensIn,
+						TokensOut:    tokensOut,
+						FinishReason: finishReason,
+					}, nil
+				}
+
+				if req.Debug {
+					fmt.Fprintf(os.Stderr, "[debug] litellm responses status=%d body=%s\n", status, strings.TrimSpace(string(respBody)))
+				}
+				if status == http.StatusNotFound {
+					lastErr = fmt.Errorf("litellm responses API error (%d): %s", status, string(respBody))
+					break // try next URL variant
+				}
+				if status == http.StatusBadRequest && isUnsupportedParameter(respBody) {
+					lastErr = fmt.Errorf("litellm responses API error (%d): %s", status, string(respBody))
+					continue // try next payload variant
+				}
+				if status >= http.StatusInternalServerError {
+					lastErr = fmt.Errorf("litellm responses API error (%d): %s", status, string(respBody))
+					break // try next URL variant
+				}
+				return nil, fmt.Errorf("litellm responses API error (%d): %s", status, string(respBody))
 			}
-			if status == http.StatusNotFound {
-				lastErr = fmt.Errorf("litellm responses API error (%d): %s", status, string(respBody))
-				break // try next URL variant
-			}
-			if status == http.StatusBadRequest && isUnsupportedParameter(respBody) {
-				lastErr = fmt.Errorf("litellm responses API error (%d): %s", status, string(respBody))
-				continue // try next payload variant
-			}
-			if status >= http.StatusInternalServerError {
-				lastErr = fmt.Errorf("litellm responses API error (%d): %s", status, string(respBody))
-				break // try next URL variant
-			}
-			return nil, fmt.Errorf("litellm responses API error (%d): %s", status, string(respBody))
-		}
 		}
 	}
 
@@ -335,9 +340,9 @@ func responsesInputFromMessages(messages []Message) []map[string]interface{} {
 
 func parseResponsesSSE(body []byte) (string, int, int, string, error) {
 	type event struct {
-		Type     string `json:"type"`
-		Delta    string `json:"delta"`
-		Error    struct {
+		Type  string `json:"type"`
+		Delta string `json:"delta"`
+		Error struct {
 			Message string `json:"message"`
 		} `json:"error"`
 		Response struct {
@@ -376,9 +381,9 @@ func parseResponsesSSE(body []byte) (string, int, int, string, error) {
 		if err := json.Unmarshal([]byte(data), &ev); err != nil {
 			return nil
 		}
-			if ev.Error.Message != "" {
-				return errors.New(ev.Error.Message)
-			}
+		if ev.Error.Message != "" {
+			return errors.New(ev.Error.Message)
+		}
 		switch ev.Type {
 		case "response.output_text.delta":
 			content.WriteString(ev.Delta)

--- a/internal/ai/litellm_test.go
+++ b/internal/ai/litellm_test.go
@@ -563,21 +563,14 @@ func TestLiteLLMDebugAndSystemBranches(t *testing.T) {
 }
 
 func TestLiteLLMGenericReturnBranchesAndDebugFallback(t *testing.T) {
-	prevChat := chatCompletionURLCandidates
-	prevResp := responsesURLCandidates
-	t.Cleanup(func() {
-		chatCompletionURLCandidates = prevChat
-		responsesURLCandidates = prevResp
-	})
-
-	chatCompletionURLCandidates = func(base string) []string { return nil }
 	client := NewLiteLLMClient("http://example.com", "k", "plain-model")
+	client.chatCompletionURLCandidates = func(base string) []string { return nil }
 	_, err := client.completeChatCompletions(context.Background(), &CompletionRequest{Model: "plain-model"})
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "litellm API request failed on all chat/completions URL variants")
 
-	responsesURLCandidates = func(base string) []string { return nil }
 	client = NewLiteLLMClient("http://example.com", "k", "gpt-5-codex")
+	client.responsesURLCandidates = func(base string) []string { return nil }
 	_, err = client.completeResponses(context.Background(), &CompletionRequest{Model: "gpt-5-codex"})
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "litellm responses request failed on all URL and token-field variants")
@@ -593,8 +586,6 @@ func TestLiteLLMGenericReturnBranchesAndDebugFallback(t *testing.T) {
 	}))
 	defer server.Close()
 
-	responsesURLCandidates = prevResp
-	chatCompletionURLCandidates = prevChat
 	client = NewLiteLLMClient(server.URL, "k", "gpt-5-codex")
 	client.client = server.Client()
 

--- a/internal/ai/litellm_test.go
+++ b/internal/ai/litellm_test.go
@@ -1,12 +1,17 @@
 package ai
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -117,4 +122,545 @@ func TestLiteLLMClientCompleteFallsBackToChatCompletions(t *testing.T) {
 	assert.Equal(t, "fallback-ok", resp.Content)
 	assert.GreaterOrEqual(t, hits["/v1/responses"], 1)
 	assert.Equal(t, 1, hits["/v1/chat/completions"])
+}
+
+func TestLiteLLMHelpersAndErrors(t *testing.T) {
+	resp, err := parseChatCompletionsResponse([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2},"model":"m"}`))
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp.Content)
+
+	_, err = parseChatCompletionsResponse([]byte(`{`))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to parse litellm response")
+
+	_, err = parseChatCompletionsResponse([]byte(`{"choices":[]}`))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "no choices returned from litellm")
+
+	assert.Equal(t, []string{"a", "b"}, uniqueStrings([]string{"a", "a", "b"}))
+	assert.Contains(t, candidateResponsesURLs("http://x/v1"), "http://x/v1/responses")
+	assert.Contains(t, candidateChatCompletionURLs("http://x/openai/v1"), "http://x/v1/chat/completions")
+	assert.Equal(t, []string{"http://x/v1/openai/v1", "http://x/v1/openai", "http://x/v1", "http://x"}, normalizedBaseCandidates("http://x/v1/openai/v1"))
+	assert.True(t, isUnsupportedParameter([]byte("Unsupported parameter: foo")))
+	assert.False(t, isUnsupportedParameter([]byte("other")))
+}
+
+func TestParseResponsesSSEVariants(t *testing.T) {
+	sse := "" +
+		"data: {\"type\":\"response.completed\",\"response\":{\"status\":\"done\",\"output\":[{\"content\":[{\"type\":\"output_text\",\"text\":\"Hello\"},{\"type\":\"text\",\"text\":\" world\"}]}],\"usage\":{\"input_tokens\":2,\"output_tokens\":3}}}\n\n"
+	content, in, out, reason, err := parseResponsesSSE([]byte(sse))
+	require.NoError(t, err)
+	assert.Equal(t, "Hello world", content)
+	assert.Equal(t, 2, in)
+	assert.Equal(t, 3, out)
+	assert.Equal(t, "done", reason)
+
+	_, _, _, _, err = parseResponsesSSE([]byte("data: {\"error\":{\"message\":\"bad\"}}\n\n"))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "bad")
+
+	_, _, _, _, err = parseResponsesSSE([]byte("data: {not-json}\n\n"))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "empty responses output")
+}
+
+func TestLiteLLMDoJSONPostAndCompleteBranches(t *testing.T) {
+	client := NewLiteLLMClient("http://example.com", "key", "m")
+	_, _, err := client.doJSONPost(context.Background(), "http://example.com", map[string]interface{}{"bad": math.NaN()})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to marshal request")
+
+	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       errReadCloser{},
+			Header:     make(http.Header),
+		}, nil
+	})}
+	_, _, err = client.doJSONPost(context.Background(), "http://example.com", map[string]interface{}{"ok": true})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to read response")
+
+	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("network down")
+	})}
+	_, err = client.Complete(context.Background(), &CompletionRequest{Model: "plain-model", MaxTokens: 1})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "litellm request failed")
+}
+
+func TestLiteLLMCompleteAdditionalBranches(t *testing.T) {
+	t.Run("chat direct success with debug", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2},"model":"plain-model"}`))
+		}))
+		defer server.Close()
+
+		client := NewLiteLLMClient(server.URL, "test-key", "plain-model")
+		client.client = server.Client()
+
+		stderr := os.Stderr
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		os.Stderr = w
+
+		resp, err := client.Complete(context.Background(), &CompletionRequest{
+			Model:       "plain-model",
+			Debug:       true,
+			Messages:    []Message{{Role: "user", Content: "hi"}},
+			MaxTokens:   4,
+			Temperature: 0.1,
+		})
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+		os.Stderr = stderr
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, r)
+		require.NoError(t, err)
+		require.NoError(t, r.Close())
+		assert.Equal(t, "ok", resp.Content)
+		assert.Contains(t, buf.String(), "[debug] litellm request")
+		assert.Contains(t, buf.String(), "[debug] litellm response status=200")
+	})
+
+	t.Run("responses api hard error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`denied`))
+		}))
+		defer server.Close()
+
+		client := NewLiteLLMClient(server.URL, "test-key", "gpt-5-codex")
+		client.client = server.Client()
+
+		_, err := client.Complete(context.Background(), &CompletionRequest{Model: "gpt-5-codex", MaxTokens: 4})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "litellm API error (401): denied")
+	})
+
+	t.Run("chat api hard error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`denied`))
+		}))
+		defer server.Close()
+
+		client := NewLiteLLMClient(server.URL, "test-key", "plain-model")
+		client.client = server.Client()
+
+		_, err := client.Complete(context.Background(), &CompletionRequest{Model: "plain-model", MaxTokens: 4})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "litellm API error (401): denied")
+	})
+}
+
+func TestLiteLLMNameAndMoreSSEBranches(t *testing.T) {
+	client := NewLiteLLMClient("http://example.com", "k", "m")
+	assert.Equal(t, "litellm", client.Name())
+
+	longLine := "data: " + string(bytes.Repeat([]byte("a"), 70000)) + "\n"
+	_, _, _, _, err := parseResponsesSSE([]byte(longLine))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed reading SSE stream")
+}
+
+func TestLiteLLMMethodLevelBranchCoverage(t *testing.T) {
+	t.Run("chat completions parse error after 200", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{`))
+		}))
+		defer server.Close()
+
+		client := NewLiteLLMClient(server.URL, "test-key", "plain-model")
+		client.client = server.Client()
+		_, err := client.completeChatCompletions(context.Background(), &CompletionRequest{Model: "plain-model", MaxTokens: 4})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed to parse litellm response")
+	})
+
+	t.Run("chat completions not found exhausts variants", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`missing`))
+		}))
+		defer server.Close()
+
+		client := NewLiteLLMClient(server.URL, "test-key", "plain-model")
+		client.client = server.Client()
+		_, err := client.completeChatCompletions(context.Background(), &CompletionRequest{Model: "plain-model", MaxTokens: 4})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "litellm API error (404): missing")
+	})
+
+	t.Run("chat completions server error exhausts variants", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`boom`))
+		}))
+		defer server.Close()
+
+		client := NewLiteLLMClient(server.URL, "test-key", "plain-model")
+		client.client = server.Client()
+		_, err := client.completeChatCompletions(context.Background(), &CompletionRequest{Model: "plain-model", MaxTokens: 4})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "litellm API error (500): boom")
+	})
+
+	t.Run("chat completions malformed url", func(t *testing.T) {
+		client := NewLiteLLMClient("://bad", "test-key", "plain-model")
+		_, err := client.completeChatCompletions(context.Background(), &CompletionRequest{Model: "plain-model", MaxTokens: 4})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "litellm request failed")
+	})
+
+	t.Run("chat completions unsupported parameter retries next token field", func(t *testing.T) {
+		var tokenFieldNames []string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			var payload map[string]interface{}
+			require.NoError(t, json.Unmarshal(body, &payload))
+			if _, ok := payload["max_tokens"]; ok {
+				tokenFieldNames = append(tokenFieldNames, "max_tokens")
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`unsupported parameter`))
+				return
+			}
+			if _, ok := payload["max_completion_tokens"]; ok {
+				tokenFieldNames = append(tokenFieldNames, "max_completion_tokens")
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2},"model":"plain-model"}`))
+		}))
+		defer server.Close()
+
+		client := NewLiteLLMClient(server.URL, "test-key", "plain-model")
+		client.client = server.Client()
+		resp, err := client.completeChatCompletions(context.Background(), &CompletionRequest{Model: "plain-model", MaxTokens: 4})
+		require.NoError(t, err)
+		assert.Equal(t, "ok", resp.Content)
+		assert.Equal(t, []string{"max_tokens", "max_completion_tokens"}, tokenFieldNames)
+	})
+
+	t.Run("chat completions not found breaks to next url variant", func(t *testing.T) {
+		var paths []string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			paths = append(paths, r.URL.Path)
+			if len(paths) == 1 {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`missing`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2},"model":"plain-model"}`))
+		}))
+		defer server.Close()
+
+		client := NewLiteLLMClient(server.URL+"/v1", "test-key", "plain-model")
+		client.client = server.Client()
+		resp, err := client.completeChatCompletions(context.Background(), &CompletionRequest{Model: "plain-model", MaxTokens: 4})
+		require.NoError(t, err)
+		assert.Equal(t, "ok", resp.Content)
+		assert.GreaterOrEqual(t, len(paths), 2)
+	})
+
+	t.Run("responses parse error after 200", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`data: {` + "\n\n"))
+		}))
+		defer server.Close()
+
+		client := NewLiteLLMClient(server.URL, "test-key", "gpt-5-codex")
+		client.client = server.Client()
+		_, err := client.completeResponses(context.Background(), &CompletionRequest{Model: "gpt-5-codex", MaxTokens: 4})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed to parse litellm responses stream")
+	})
+
+	t.Run("responses not found exhausts variants", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`missing`))
+		}))
+		defer server.Close()
+
+		client := NewLiteLLMClient(server.URL, "test-key", "gpt-5-codex")
+		client.client = server.Client()
+		_, err := client.completeResponses(context.Background(), &CompletionRequest{Model: "gpt-5-codex", MaxTokens: 4})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "litellm responses API error (404): missing")
+	})
+
+	t.Run("responses server error exhausts variants", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`boom`))
+		}))
+		defer server.Close()
+
+		client := NewLiteLLMClient(server.URL, "test-key", "gpt-5-codex")
+		client.client = server.Client()
+		_, err := client.completeResponses(context.Background(), &CompletionRequest{Model: "gpt-5-codex", MaxTokens: 4})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "litellm responses API error (500): boom")
+	})
+
+	t.Run("responses malformed url", func(t *testing.T) {
+		client := NewLiteLLMClient("://bad", "test-key", "gpt-5-codex")
+		_, err := client.completeResponses(context.Background(), &CompletionRequest{Model: "gpt-5-codex", MaxTokens: 4})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "litellm responses request failed")
+	})
+
+	t.Run("responses unsupported parameter retries variants", func(t *testing.T) {
+		var attempts int
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			attempts++
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			text := string(body)
+			if strings.Contains(text, "max_output_tokens") {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`unsupported parameter`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"output_text\":\"ok\",\"usage\":{\"input_tokens\":1,\"output_tokens\":2}}}\n\n"))
+		}))
+		defer server.Close()
+
+		client := NewLiteLLMClient(server.URL, "test-key", "gpt-5-codex")
+		client.client = server.Client()
+		resp, err := client.completeResponses(context.Background(), &CompletionRequest{Model: "gpt-5-codex", MaxTokens: 4})
+		require.NoError(t, err)
+		assert.Equal(t, "ok", resp.Content)
+		assert.GreaterOrEqual(t, attempts, 2)
+	})
+
+	t.Run("responses include temperature fallback branch", func(t *testing.T) {
+		var payloads []string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			payloads = append(payloads, string(body))
+			if strings.Contains(string(body), "\"temperature\"") {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`unsupported parameter`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"output_text\":\"ok\",\"usage\":{\"input_tokens\":1,\"output_tokens\":2}}}\n\n"))
+		}))
+		defer server.Close()
+
+		client := NewLiteLLMClient(server.URL, "test-key", "gpt-5-codex")
+		client.client = server.Client()
+		resp, err := client.completeResponses(context.Background(), &CompletionRequest{Model: "gpt-5-codex", MaxTokens: 4, Temperature: 0.7})
+		require.NoError(t, err)
+		assert.Equal(t, "ok", resp.Content)
+		require.Len(t, payloads, 2)
+		assert.Contains(t, payloads[0], "\"temperature\"")
+		assert.NotContains(t, payloads[1], "\"temperature\"")
+	})
+
+	t.Run("responses token field none branch", func(t *testing.T) {
+		var payloads []string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			payloads = append(payloads, string(body))
+			if len(payloads) < 4 {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`unsupported parameter`))
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"output_text\":\"ok\",\"usage\":{\"input_tokens\":1,\"output_tokens\":2}}}\n\n"))
+		}))
+		defer server.Close()
+
+		client := NewLiteLLMClient(server.URL, "test-key", "gpt-5-codex")
+		client.client = server.Client()
+		resp, err := client.completeResponses(context.Background(), &CompletionRequest{Model: "gpt-5-codex", MaxTokens: 4})
+		require.NoError(t, err)
+		assert.Equal(t, "ok", resp.Content)
+		require.Len(t, payloads, 4)
+		assert.NotContains(t, payloads[3], "max_output_tokens")
+		assert.NotContains(t, payloads[3], "max_tokens")
+		assert.NotContains(t, payloads[3], "max_completion_tokens")
+	})
+
+	t.Run("do json post malformed url", func(t *testing.T) {
+		client := NewLiteLLMClient("http://example.com", "key", "m")
+		_, _, err := client.doJSONPost(context.Background(), "://bad", map[string]interface{}{"ok": true})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed to create request")
+	})
+}
+
+func TestParseResponsesSSEAdditionalBranches(t *testing.T) {
+	sse := "" +
+		"event: ignored\n" +
+		"data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hello\"}\n\n" +
+		"data: {\"usage\":{\"input_tokens\":3,\"output_tokens\":4}}\n\n" +
+		"data: {\"type\":\"response.completed\",\"response\":{\"status\":\"\",\"output_text\":\" world\"}}\n\n"
+
+	content, in, out, reason, err := parseResponsesSSE([]byte(sse))
+	require.NoError(t, err)
+	assert.Equal(t, "Hello", content)
+	assert.Equal(t, 3, in)
+	assert.Equal(t, 4, out)
+	assert.Equal(t, "completed", reason)
+}
+
+func TestParseResponsesSSETrailingDataWithoutBlankLine(t *testing.T) {
+	content, _, _, _, err := parseResponsesSSE([]byte("data: {\"type\":\"response.completed\",\"response\":{\"output_text\":\"ok\"}}"))
+	require.NoError(t, err)
+	assert.Equal(t, "ok", content)
+
+	_, _, _, _, err = parseResponsesSSE([]byte("data: {\"error\":{\"message\":\"bad\"}}"))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "bad")
+}
+
+func TestLiteLLMDebugAndSystemBranches(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		assert.Contains(t, string(body), "\"role\":\"system\"")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2},"model":"plain-model"}`))
+	}))
+	defer server.Close()
+
+	client := NewLiteLLMClient(server.URL, "test-key", "plain-model")
+	client.client = server.Client()
+
+	stderr := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+
+	_, err = client.completeChatCompletions(context.Background(), &CompletionRequest{
+		Model:     "plain-model",
+		System:    "system prompt",
+		Debug:     true,
+		MaxTokens: 4,
+	})
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	os.Stderr = stderr
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	assert.Contains(t, buf.String(), "[debug] litellm request")
+}
+
+func TestLiteLLMGenericReturnBranchesAndDebugFallback(t *testing.T) {
+	prevChat := chatCompletionURLCandidates
+	prevResp := responsesURLCandidates
+	t.Cleanup(func() {
+		chatCompletionURLCandidates = prevChat
+		responsesURLCandidates = prevResp
+	})
+
+	chatCompletionURLCandidates = func(base string) []string { return nil }
+	client := NewLiteLLMClient("http://example.com", "k", "plain-model")
+	_, err := client.completeChatCompletions(context.Background(), &CompletionRequest{Model: "plain-model"})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "litellm API request failed on all chat/completions URL variants")
+
+	responsesURLCandidates = func(base string) []string { return nil }
+	client = NewLiteLLMClient("http://example.com", "k", "gpt-5-codex")
+	_, err = client.completeResponses(context.Background(), &CompletionRequest{Model: "gpt-5-codex"})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "litellm responses request failed on all URL and token-field variants")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "responses") {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte(`boom`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2},"model":"gpt-5-codex"}`))
+	}))
+	defer server.Close()
+
+	responsesURLCandidates = prevResp
+	chatCompletionURLCandidates = prevChat
+	client = NewLiteLLMClient(server.URL, "k", "gpt-5-codex")
+	client.client = server.Client()
+
+	stderr := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+	_, err = client.Complete(context.Background(), &CompletionRequest{Model: "gpt-5-codex", Debug: true})
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	os.Stderr = stderr
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	assert.Contains(t, buf.String(), "responses failed; retrying with chat/completions fallback")
+}
+
+func TestLiteLLMDebugStatusBranches(t *testing.T) {
+	t.Run("chat completions debug error body", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`denied`))
+		}))
+		defer server.Close()
+
+		client := NewLiteLLMClient(server.URL, "k", "plain-model")
+		client.client = server.Client()
+
+		stderr := os.Stderr
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		os.Stderr = w
+		_, err = client.completeChatCompletions(context.Background(), &CompletionRequest{Model: "plain-model", Debug: true, MaxTokens: 1})
+		require.Error(t, err)
+		require.NoError(t, w.Close())
+		os.Stderr = stderr
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, r)
+		require.NoError(t, err)
+		require.NoError(t, r.Close())
+		assert.Contains(t, buf.String(), "[debug] litellm response status=400 body=denied")
+	})
+
+	t.Run("responses debug success line", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"output_text\":\"ok\"}}\n\n"))
+		}))
+		defer server.Close()
+
+		client := NewLiteLLMClient(server.URL, "k", "gpt-5-codex")
+		client.client = server.Client()
+
+		stderr := os.Stderr
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		os.Stderr = w
+		_, err = client.completeResponses(context.Background(), &CompletionRequest{Model: "gpt-5-codex", Debug: true, MaxTokens: 1})
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+		os.Stderr = stderr
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, r)
+		require.NoError(t, err)
+		require.NoError(t, r.Close())
+		assert.Contains(t, buf.String(), "[debug] litellm responses status=200")
+	})
 }

--- a/internal/cli/review.go
+++ b/internal/cli/review.go
@@ -16,6 +16,12 @@ type reviewExecutor interface {
 	Review(ctx context.Context, owner, repo string, prNumber int, dryRun bool) (*model.ReviewResult, error)
 }
 
+type reviewDeps struct {
+	newGitHubPRClient func(token string) github.PRClient
+	newReviewExecutor func(aiClient ai.AIClient, ghClient github.PRClient, cfg *config.Config) reviewExecutor
+	buildAIClient     func(cfg *config.Config) (ai.AIClient, error)
+}
+
 func defaultGitHubPRClient(token string) github.PRClient {
 	return github.NewGitHubClient(token)
 }
@@ -24,13 +30,19 @@ func defaultReviewExecutor(aiClient ai.AIClient, ghClient github.PRClient, cfg *
 	return review.NewOrchestrator(aiClient, ghClient, cfg)
 }
 
-var (
-	newGitHubPRClient = defaultGitHubPRClient
-	newReviewExecutor = defaultReviewExecutor
-	buildAIClient     = newAIClient
-)
+func defaultReviewDeps() reviewDeps {
+	return reviewDeps{
+		newGitHubPRClient: defaultGitHubPRClient,
+		newReviewExecutor: defaultReviewExecutor,
+		buildAIClient:     newAIClient,
+	}
+}
 
 func runReview(cmd *cobra.Command, args []string) error {
+	return runReviewWithDeps(cmd, args, defaultReviewDeps())
+}
+
+func runReviewWithDeps(cmd *cobra.Command, args []string, deps reviewDeps) error {
 	cfg, err := loadReviewConfig(cmd)
 	if err != nil {
 		return err
@@ -50,13 +62,13 @@ func runReview(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	aiClient, err := buildAIClient(cfg)
+	aiClient, err := deps.buildAIClient(cfg)
 	if err != nil {
 		return err
 	}
 
-	ghClient := newGitHubPRClient(cfg.GitHub.Token)
-	orch := newReviewExecutor(aiClient, ghClient, cfg)
+	ghClient := deps.newGitHubPRClient(cfg.GitHub.Token)
+	orch := deps.newReviewExecutor(aiClient, ghClient, cfg)
 
 	result, err := orch.Review(cmd.Context(), owner, repo, prNumber, flagDryRun)
 	if err != nil {

--- a/internal/cli/review.go
+++ b/internal/cli/review.go
@@ -1,13 +1,33 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/AtomicWasTaken/surge/internal/ai"
 	"github.com/AtomicWasTaken/surge/internal/config"
 	"github.com/AtomicWasTaken/surge/internal/github"
+	"github.com/AtomicWasTaken/surge/internal/model"
 	"github.com/AtomicWasTaken/surge/internal/review"
 	"github.com/spf13/cobra"
+)
+
+type reviewExecutor interface {
+	Review(ctx context.Context, owner, repo string, prNumber int, dryRun bool) (*model.ReviewResult, error)
+}
+
+func defaultGitHubPRClient(token string) github.PRClient {
+	return github.NewGitHubClient(token)
+}
+
+func defaultReviewExecutor(aiClient ai.AIClient, ghClient github.PRClient, cfg *config.Config) reviewExecutor {
+	return review.NewOrchestrator(aiClient, ghClient, cfg)
+}
+
+var (
+	newGitHubPRClient = defaultGitHubPRClient
+	newReviewExecutor = defaultReviewExecutor
+	buildAIClient     = newAIClient
 )
 
 func runReview(cmd *cobra.Command, args []string) error {
@@ -30,13 +50,13 @@ func runReview(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	aiClient, err := newAIClient(cfg)
+	aiClient, err := buildAIClient(cfg)
 	if err != nil {
 		return err
 	}
 
-	ghClient := github.NewGitHubClient(cfg.GitHub.Token)
-	orch := review.NewOrchestrator(aiClient, ghClient, cfg)
+	ghClient := newGitHubPRClient(cfg.GitHub.Token)
+	orch := newReviewExecutor(aiClient, ghClient, cfg)
 
 	result, err := orch.Review(cmd.Context(), owner, repo, prNumber, flagDryRun)
 	if err != nil {

--- a/internal/cli/review_test.go
+++ b/internal/cli/review_test.go
@@ -214,6 +214,23 @@ func TestResolveReviewTarget(t *testing.T) {
 		assert.Equal(t, "surge", repo)
 		assert.Equal(t, 7, pr)
 	})
+
+	t.Run("returns detection error when git info lookup fails", func(t *testing.T) {
+		prevGetwd := getwd
+		getwd = func() (string, error) {
+			return "", errors.New("boom")
+		}
+		t.Cleanup(func() {
+			getwd = prevGetwd
+		})
+
+		_, _, _, err := resolveReviewTarget(&config.Config{
+			GitHub: config.GitHubConfig{PRNumber: 1},
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "could not detect owner/repo")
+		assert.ErrorContains(t, err, "boom")
+	})
 }
 
 func TestValidateReviewCredentials(t *testing.T) {
@@ -321,18 +338,6 @@ func TestRunReviewEarlyErrors(t *testing.T) {
 	err := runReview(cmd, nil)
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "failed to load config")
-}
-
-func TestResolveReviewTargetDetectError(t *testing.T) {
-	tmpDir := t.TempDir()
-	prevWD, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(tmpDir))
-	t.Cleanup(func() { _ = os.Chdir(prevWD) })
-
-	_, _, _, err = resolveReviewTarget(&config.Config{GitHub: config.GitHubConfig{PRNumber: 1}})
-	require.Error(t, err)
-	assert.ErrorContains(t, err, "could not detect owner/repo")
 }
 
 func TestLoadReviewConfigInvalidConfig(t *testing.T) {

--- a/internal/cli/review_test.go
+++ b/internal/cli/review_test.go
@@ -1,12 +1,88 @@
 package cli
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/AtomicWasTaken/surge/internal/ai"
 	"github.com/AtomicWasTaken/surge/internal/config"
+	"github.com/AtomicWasTaken/surge/internal/github"
+	"github.com/AtomicWasTaken/surge/internal/model"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type dummyPRClient struct{}
+
+func (d *dummyPRClient) GetPR(ctx context.Context, owner, repo string, prNumber int) (*model.PR, error) {
+	return nil, nil
+}
+func (d *dummyPRClient) GetDiff(ctx context.Context, owner, repo string, prNumber int) (string, error) {
+	return "", nil
+}
+func (d *dummyPRClient) GetFiles(ctx context.Context, owner, repo string, prNumber int) ([]model.FileChange, error) {
+	return nil, nil
+}
+func (d *dummyPRClient) GetFileContent(ctx context.Context, owner, repo, path, ref string) (string, error) {
+	return "", nil
+}
+func (d *dummyPRClient) PostReview(ctx context.Context, owner, repo string, prNumber int, review *model.ReviewInput) error {
+	return nil
+}
+func (d *dummyPRClient) PostComment(ctx context.Context, owner, repo string, prNumber int, body string) error {
+	return nil
+}
+func (d *dummyPRClient) ListComments(ctx context.Context, owner, repo string, prNumber int) ([]*model.PRComment, error) {
+	return nil, nil
+}
+func (d *dummyPRClient) DeleteComment(ctx context.Context, owner, repo string, commentID int64) error {
+	return nil
+}
+func (d *dummyPRClient) ListReviews(ctx context.Context, owner, repo string, prNumber int) ([]*model.PRReview, error) {
+	return nil, nil
+}
+func (d *dummyPRClient) DeleteReview(ctx context.Context, owner, repo string, prNumber int, reviewID int64) error {
+	return nil
+}
+func (d *dummyPRClient) DismissReview(ctx context.Context, owner, repo string, prNumber int, reviewID int64, message string) error {
+	return nil
+}
+func (d *dummyPRClient) ListReviewComments(ctx context.Context, owner, repo string, prNumber int, reviewID int64) ([]*model.PRReviewComment, error) {
+	return nil, nil
+}
+func (d *dummyPRClient) DeleteReviewComment(ctx context.Context, owner, repo string, commentID int64) error {
+	return nil
+}
+func (d *dummyPRClient) ListLabels(ctx context.Context, owner, repo string, prNumber int) ([]string, error) {
+	return nil, nil
+}
+func (d *dummyPRClient) AddLabels(ctx context.Context, owner, repo string, prNumber int, labels []string) error {
+	return nil
+}
+func (d *dummyPRClient) RemoveLabel(ctx context.Context, owner, repo string, prNumber int, label string) error {
+	return nil
+}
+func (d *dummyPRClient) UpsertLabel(ctx context.Context, owner, repo, name, color, description string) error {
+	return nil
+}
+
+type stubReviewExecutor struct {
+	result *model.ReviewResult
+	err    error
+}
+
+func (s *stubReviewExecutor) Review(ctx context.Context, owner, repo string, prNumber int, dryRun bool) (*model.ReviewResult, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.result, nil
+}
 
 func TestApplyReviewFlagOverrides(t *testing.T) {
 	cmd := &cobra.Command{Use: "review"}
@@ -54,4 +130,534 @@ func TestApplyReviewFlagOverrides(t *testing.T) {
 	assert.Equal(t, 7, cfg.MaxInlineComments)
 	assert.Equal(t, 4096, cfg.MaxTokens)
 	assert.Equal(t, 0.6, cfg.Temperature)
+}
+
+func TestApplyReviewBooleanOverrides(t *testing.T) {
+	prevVerbose := flagVerbose
+	prevNoInline := flagNoInline
+	prevNoSummary := flagNoSummary
+	t.Cleanup(func() {
+		flagVerbose = prevVerbose
+		flagNoInline = prevNoInline
+		flagNoSummary = prevNoSummary
+	})
+
+	cmd := &cobra.Command{Use: "review"}
+	cmd.Flags().Bool("verbose", false, "")
+	require.NoError(t, cmd.Flags().Set("verbose", "true"))
+
+	flagVerbose = true
+	flagNoInline = true
+	flagNoSummary = true
+
+	cfg := &config.Config{}
+	applyReviewBooleanOverrides(cmd, cfg)
+
+	assert.True(t, cfg.Verbose)
+	assert.True(t, cfg.DisableInlineComments)
+	assert.True(t, cfg.DisableSummaryComment)
+}
+
+func TestResolveReviewTarget(t *testing.T) {
+	t.Run("uses config when complete", func(t *testing.T) {
+		owner, repo, pr, err := resolveReviewTarget(&config.Config{
+			GitHub: config.GitHubConfig{Owner: "octo", Repo: "surge", PRNumber: 12},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "octo", owner)
+		assert.Equal(t, "surge", repo)
+		assert.Equal(t, 12, pr)
+	})
+
+	t.Run("errors when pr missing", func(t *testing.T) {
+		_, _, _, err := resolveReviewTarget(&config.Config{
+			GitHub: config.GitHubConfig{Owner: "octo", Repo: "surge"},
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "PR number is required")
+	})
+
+	t.Run("fills missing owner from detection", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitDir := filepath.Join(tmpDir, ".git")
+		require.NoError(t, os.Mkdir(gitDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(gitDir, "config"), []byte("[remote \"origin\"]\n\turl = https://github.com/octo/surge.git\n"), 0644))
+		prevWD, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
+		t.Cleanup(func() { _ = os.Chdir(prevWD) })
+
+		owner, repo, pr, err := resolveReviewTarget(&config.Config{
+			GitHub: config.GitHubConfig{Repo: "custom", PRNumber: 7},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "octo", owner)
+		assert.Equal(t, "custom", repo)
+		assert.Equal(t, 7, pr)
+	})
+
+	t.Run("fills missing repo from detection", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitDir := filepath.Join(tmpDir, ".git")
+		require.NoError(t, os.Mkdir(gitDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(gitDir, "config"), []byte("[remote \"origin\"]\n\turl = https://github.com/octo/surge.git\n"), 0644))
+		prevWD, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
+		t.Cleanup(func() { _ = os.Chdir(prevWD) })
+
+		owner, repo, pr, err := resolveReviewTarget(&config.Config{
+			GitHub: config.GitHubConfig{Owner: "custom", PRNumber: 7},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "custom", owner)
+		assert.Equal(t, "surge", repo)
+		assert.Equal(t, 7, pr)
+	})
+}
+
+func TestValidateReviewCredentials(t *testing.T) {
+	require.Error(t, validateReviewCredentials(&config.Config{}))
+	require.Error(t, validateReviewCredentials(&config.Config{
+		GitHub: config.GitHubConfig{Token: "gh"},
+		AI:     config.AIConfig{Provider: "claude"},
+	}))
+	require.NoError(t, validateReviewCredentials(&config.Config{
+		GitHub: config.GitHubConfig{Token: "gh"},
+		AI:     config.AIConfig{Provider: "litellm"},
+	}))
+}
+
+func TestNewAIClient(t *testing.T) {
+	client, err := newAIClient(&config.Config{
+		AI: config.AIConfig{Provider: "litellm", BaseURL: "http://localhost:4000", APIKey: "key", Model: "m"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "litellm", client.Name())
+
+	client, err = newAIClient(&config.Config{
+		AI: config.AIConfig{Provider: "claude", APIKey: "key", Model: "claude-3-7-sonnet"},
+	})
+	require.NoError(t, err)
+	assert.IsType(t, &ai.ClaudeClient{}, client)
+
+	_, err = newAIClient(&config.Config{AI: config.AIConfig{Provider: "unknown"}})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "unknown AI provider")
+}
+
+func TestLoadReviewConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "surge.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+github:
+  token: gh
+  owner: octo
+  repo: surge
+  prNumber: 15
+ai:
+  provider: litellm
+  model: test-model
+  baseUrl: http://localhost:4000
+output:
+  format: markdown
+contextDepth: diff-only
+categories:
+  security: true
+  performance: true
+  logic: true
+  maintainability: true
+  vibe: true
+`), 0644))
+
+	prevConfig := flagConfig
+	prevVerbose := flagVerbose
+	prevNoInline := flagNoInline
+	prevNoSummary := flagNoSummary
+	t.Cleanup(func() {
+		flagConfig = prevConfig
+		flagVerbose = prevVerbose
+		flagNoInline = prevNoInline
+		flagNoSummary = prevNoSummary
+	})
+
+	flagConfig = cfgPath
+	flagVerbose = false
+	flagNoInline = false
+	flagNoSummary = false
+
+	cmd := &cobra.Command{Use: "review"}
+	cmd.Flags().String("github-token", "", "")
+	cmd.Flags().String("owner", "", "")
+	cmd.Flags().String("repo", "", "")
+	cmd.Flags().Int("pr", 0, "")
+	cmd.Flags().String("ai-provider", "", "")
+	cmd.Flags().String("ai-model", "", "")
+	cmd.Flags().String("ai-base-url", "", "")
+	cmd.Flags().String("ai-api-key", "", "")
+	cmd.Flags().String("context-depth", "", "")
+	cmd.Flags().String("output", "", "")
+	cmd.Flags().Int("max-inline", 0, "")
+	cmd.Flags().Int("max-tokens", 0, "")
+	cmd.Flags().Float64("temperature", 0, "")
+	cmd.Flags().Bool("verbose", false, "")
+
+	require.NoError(t, cmd.Flags().Set("owner", "override"))
+
+	cfg, err := loadReviewConfig(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, "override", cfg.GitHub.Owner)
+	assert.Equal(t, "surge", cfg.GitHub.Repo)
+	assert.Equal(t, 15, cfg.GitHub.PRNumber)
+}
+
+func TestRunReviewEarlyErrors(t *testing.T) {
+	cmd := &cobra.Command{Use: "review"}
+
+	prevConfig := flagConfig
+	t.Cleanup(func() { flagConfig = prevConfig })
+
+	flagConfig = filepath.Join(t.TempDir(), "missing.yaml")
+	err := runReview(cmd, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to load config")
+}
+
+func TestResolveReviewTargetDetectError(t *testing.T) {
+	tmpDir := t.TempDir()
+	prevWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	t.Cleanup(func() { _ = os.Chdir(prevWD) })
+
+	_, _, _, err = resolveReviewTarget(&config.Config{GitHub: config.GitHubConfig{PRNumber: 1}})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "could not detect owner/repo")
+}
+
+func TestLoadReviewConfigInvalidConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "surge.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+ai:
+  provider: invalid
+categories:
+  security: true
+  performance: true
+  logic: true
+  maintainability: true
+  vibe: true
+output:
+  format: terminal
+contextDepth: diff-only
+`), 0644))
+
+	prevConfig := flagConfig
+	t.Cleanup(func() { flagConfig = prevConfig })
+	flagConfig = cfgPath
+
+	cmd := &cobra.Command{Use: "review"}
+	cmd.Flags().Bool("verbose", false, "")
+	cmd.Flags().String("github-token", "", "")
+	cmd.Flags().String("owner", "", "")
+	cmd.Flags().String("repo", "", "")
+	cmd.Flags().Int("pr", 0, "")
+	cmd.Flags().String("ai-provider", "", "")
+	cmd.Flags().String("ai-model", "", "")
+	cmd.Flags().String("ai-base-url", "", "")
+	cmd.Flags().String("ai-api-key", "", "")
+	cmd.Flags().String("context-depth", "", "")
+	cmd.Flags().String("output", "", "")
+	cmd.Flags().Int("max-inline", 0, "")
+	cmd.Flags().Int("max-tokens", 0, "")
+	cmd.Flags().Float64("temperature", 0, "")
+
+	_, err := loadReviewConfig(cmd)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid config")
+}
+
+func TestNewAIClientNames(t *testing.T) {
+	litellmClient, err := newAIClient(&config.Config{
+		AI: config.AIConfig{Provider: "litellm", BaseURL: "http://localhost:4000", APIKey: "key", Model: "m"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "litellm", litellmClient.Name())
+}
+
+func TestRunReviewPrintsVerboseBeforeCredentialFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "surge.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+github:
+  owner: octo
+  repo: surge
+  prNumber: 5
+ai:
+  provider: litellm
+  model: test-model
+output:
+  format: terminal
+contextDepth: diff-only
+categories:
+  security: true
+  performance: true
+  logic: true
+  maintainability: true
+  vibe: true
+verbose: true
+`), 0644))
+
+	prevConfig := flagConfig
+	t.Cleanup(func() { flagConfig = prevConfig })
+	flagConfig = cfgPath
+
+	cmd := &cobra.Command{Use: "review"}
+	cmd.Flags().Bool("verbose", false, "")
+	cmd.Flags().String("github-token", "", "")
+	cmd.Flags().String("owner", "", "")
+	cmd.Flags().String("repo", "", "")
+	cmd.Flags().Int("pr", 0, "")
+	cmd.Flags().String("ai-provider", "", "")
+	cmd.Flags().String("ai-model", "", "")
+	cmd.Flags().String("ai-base-url", "", "")
+	cmd.Flags().String("ai-api-key", "", "")
+	cmd.Flags().String("context-depth", "", "")
+	cmd.Flags().String("output", "", "")
+	cmd.Flags().Int("max-inline", 0, "")
+	cmd.Flags().Int("max-tokens", 0, "")
+	cmd.Flags().Float64("temperature", 0, "")
+
+	stdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	err = runReview(cmd, nil)
+
+	require.NoError(t, w.Close())
+	os.Stdout = stdout
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "GitHub token is required")
+
+	var buf bytes.Buffer
+	_, readErr := io.Copy(&buf, r)
+	require.NoError(t, readErr)
+	require.NoError(t, r.Close())
+	assert.Contains(t, buf.String(), "[debug] review config owner=octo repo=surge pr=5")
+}
+
+func TestRunReviewSuccessAndReviewFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "surge.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+github:
+  token: gh
+  owner: octo
+  repo: surge
+  prNumber: 5
+ai:
+  provider: litellm
+  model: test-model
+  baseUrl: http://localhost:4000
+output:
+  format: terminal
+contextDepth: diff-only
+categories:
+  security: true
+  performance: true
+  logic: true
+  maintainability: true
+  vibe: true
+`), 0644))
+
+	prevConfig := flagConfig
+	prevDryRun := flagDryRun
+	prevGitHubFactory := newGitHubPRClient
+	prevExecFactory := newReviewExecutor
+	prevBuildAIClient := buildAIClient
+	t.Cleanup(func() {
+		flagConfig = prevConfig
+		flagDryRun = prevDryRun
+		newGitHubPRClient = prevGitHubFactory
+		newReviewExecutor = prevExecFactory
+		buildAIClient = prevBuildAIClient
+	})
+	flagConfig = cfgPath
+	newGitHubPRClient = func(token string) github.PRClient { return &dummyPRClient{} }
+
+	makeCmd := func() *cobra.Command {
+		cmd := &cobra.Command{Use: "review"}
+		cmd.Flags().Bool("verbose", false, "")
+		cmd.Flags().String("github-token", "", "")
+		cmd.Flags().String("owner", "", "")
+		cmd.Flags().String("repo", "", "")
+		cmd.Flags().Int("pr", 0, "")
+		cmd.Flags().String("ai-provider", "", "")
+		cmd.Flags().String("ai-model", "", "")
+		cmd.Flags().String("ai-base-url", "", "")
+		cmd.Flags().String("ai-api-key", "", "")
+		cmd.Flags().String("context-depth", "", "")
+		cmd.Flags().String("output", "", "")
+		cmd.Flags().Int("max-inline", 0, "")
+		cmd.Flags().Int("max-tokens", 0, "")
+		cmd.Flags().Float64("temperature", 0, "")
+		return cmd
+	}
+
+	t.Run("dry run success", func(t *testing.T) {
+		flagDryRun = true
+		newReviewExecutor = func(aiClient ai.AIClient, ghClient github.PRClient, cfg *config.Config) reviewExecutor {
+			return &stubReviewExecutor{result: &model.ReviewResult{Approve: true}}
+		}
+
+		stdout := os.Stdout
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		os.Stdout = w
+
+		err = runReview(makeCmd(), nil)
+
+		require.NoError(t, w.Close())
+		os.Stdout = stdout
+		require.NoError(t, err)
+
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, r)
+		require.NoError(t, err)
+		require.NoError(t, r.Close())
+		assert.Contains(t, buf.String(), "[DRY RUN] No changes posted to the PR.")
+	})
+
+	t.Run("post success", func(t *testing.T) {
+		flagDryRun = false
+		newReviewExecutor = func(aiClient ai.AIClient, ghClient github.PRClient, cfg *config.Config) reviewExecutor {
+			return &stubReviewExecutor{result: &model.ReviewResult{Approve: false}}
+		}
+
+		stdout := os.Stdout
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		os.Stdout = w
+
+		err = runReview(makeCmd(), nil)
+
+		require.NoError(t, w.Close())
+		os.Stdout = stdout
+		require.NoError(t, err)
+
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, r)
+		require.NoError(t, err)
+		require.NoError(t, r.Close())
+		assert.Contains(t, buf.String(), "Review posted to octo/surge#5")
+	})
+
+	t.Run("review failure", func(t *testing.T) {
+		newReviewExecutor = func(aiClient ai.AIClient, ghClient github.PRClient, cfg *config.Config) reviewExecutor {
+			return &stubReviewExecutor{err: errors.New("boom")}
+		}
+
+		err := runReview(makeCmd(), nil)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "review failed: boom")
+	})
+}
+
+func TestRunReviewAdditionalErrorBranches(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "surge.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+github:
+  token: gh
+  prNumber: 5
+ai:
+  provider: litellm
+  model: test-model
+  baseUrl: http://localhost:4000
+output:
+  format: terminal
+contextDepth: diff-only
+categories:
+  security: true
+  performance: true
+  logic: true
+  maintainability: true
+  vibe: true
+`), 0644))
+
+	prevConfig := flagConfig
+	prevBuildAIClient := buildAIClient
+	t.Cleanup(func() {
+		flagConfig = prevConfig
+		buildAIClient = prevBuildAIClient
+	})
+	flagConfig = cfgPath
+
+	makeCmd := func() *cobra.Command {
+		cmd := &cobra.Command{Use: "review"}
+		cmd.Flags().Bool("verbose", false, "")
+		cmd.Flags().String("github-token", "", "")
+		cmd.Flags().String("owner", "", "")
+		cmd.Flags().String("repo", "", "")
+		cmd.Flags().Int("pr", 0, "")
+		cmd.Flags().String("ai-provider", "", "")
+		cmd.Flags().String("ai-model", "", "")
+		cmd.Flags().String("ai-base-url", "", "")
+		cmd.Flags().String("ai-api-key", "", "")
+		cmd.Flags().String("context-depth", "", "")
+		cmd.Flags().String("output", "", "")
+		cmd.Flags().Int("max-inline", 0, "")
+		cmd.Flags().Int("max-tokens", 0, "")
+		cmd.Flags().Float64("temperature", 0, "")
+		return cmd
+	}
+
+	t.Run("resolve target error", func(t *testing.T) {
+		prevWD, chErr := os.Getwd()
+		require.NoError(t, chErr)
+		require.NoError(t, os.Chdir(t.TempDir()))
+		t.Cleanup(func() { _ = os.Chdir(prevWD) })
+		t.Setenv("GITHUB_REPOSITORY", "")
+
+		err := runReview(makeCmd(), nil)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "could not detect owner/repo")
+	})
+
+	t.Run("build ai client error", func(t *testing.T) {
+		require.NoError(t, os.WriteFile(cfgPath, []byte(`
+github:
+  token: gh
+  owner: octo
+  repo: surge
+  prNumber: 5
+ai:
+  provider: litellm
+  model: test-model
+  baseUrl: http://localhost:4000
+output:
+  format: terminal
+contextDepth: diff-only
+categories:
+  security: true
+  performance: true
+  logic: true
+  maintainability: true
+  vibe: true
+`), 0644))
+		buildAIClient = func(cfg *config.Config) (ai.AIClient, error) {
+			return nil, errors.New("boom")
+		}
+		err := runReview(makeCmd(), nil)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "boom")
+	})
+}
+
+func TestDefaultFactories(t *testing.T) {
+	client := defaultGitHubPRClient("token")
+	require.NotNil(t, client)
+	exec := defaultReviewExecutor(nil, client, &config.Config{CommentMarker: "SURGE"})
+	require.NotNil(t, exec)
 }

--- a/internal/cli/review_test.go
+++ b/internal/cli/review_test.go
@@ -478,18 +478,14 @@ categories:
 
 	prevConfig := flagConfig
 	prevDryRun := flagDryRun
-	prevGitHubFactory := newGitHubPRClient
-	prevExecFactory := newReviewExecutor
-	prevBuildAIClient := buildAIClient
 	t.Cleanup(func() {
 		flagConfig = prevConfig
 		flagDryRun = prevDryRun
-		newGitHubPRClient = prevGitHubFactory
-		newReviewExecutor = prevExecFactory
-		buildAIClient = prevBuildAIClient
 	})
 	flagConfig = cfgPath
-	newGitHubPRClient = func(token string) github.PRClient { return &dummyPRClient{} }
+
+	deps := defaultReviewDeps()
+	deps.newGitHubPRClient = func(token string) github.PRClient { return &dummyPRClient{} }
 
 	makeCmd := func() *cobra.Command {
 		cmd := &cobra.Command{Use: "review"}
@@ -512,7 +508,8 @@ categories:
 
 	t.Run("dry run success", func(t *testing.T) {
 		flagDryRun = true
-		newReviewExecutor = func(aiClient ai.AIClient, ghClient github.PRClient, cfg *config.Config) reviewExecutor {
+		runDeps := deps
+		runDeps.newReviewExecutor = func(aiClient ai.AIClient, ghClient github.PRClient, cfg *config.Config) reviewExecutor {
 			return &stubReviewExecutor{result: &model.ReviewResult{Approve: true}}
 		}
 
@@ -521,7 +518,7 @@ categories:
 		require.NoError(t, err)
 		os.Stdout = w
 
-		err = runReview(makeCmd(), nil)
+		err = runReviewWithDeps(makeCmd(), nil, runDeps)
 
 		require.NoError(t, w.Close())
 		os.Stdout = stdout
@@ -536,7 +533,8 @@ categories:
 
 	t.Run("post success", func(t *testing.T) {
 		flagDryRun = false
-		newReviewExecutor = func(aiClient ai.AIClient, ghClient github.PRClient, cfg *config.Config) reviewExecutor {
+		runDeps := deps
+		runDeps.newReviewExecutor = func(aiClient ai.AIClient, ghClient github.PRClient, cfg *config.Config) reviewExecutor {
 			return &stubReviewExecutor{result: &model.ReviewResult{Approve: false}}
 		}
 
@@ -545,7 +543,7 @@ categories:
 		require.NoError(t, err)
 		os.Stdout = w
 
-		err = runReview(makeCmd(), nil)
+		err = runReviewWithDeps(makeCmd(), nil, runDeps)
 
 		require.NoError(t, w.Close())
 		os.Stdout = stdout
@@ -559,11 +557,12 @@ categories:
 	})
 
 	t.Run("review failure", func(t *testing.T) {
-		newReviewExecutor = func(aiClient ai.AIClient, ghClient github.PRClient, cfg *config.Config) reviewExecutor {
+		runDeps := deps
+		runDeps.newReviewExecutor = func(aiClient ai.AIClient, ghClient github.PRClient, cfg *config.Config) reviewExecutor {
 			return &stubReviewExecutor{err: errors.New("boom")}
 		}
 
-		err := runReview(makeCmd(), nil)
+		err := runReviewWithDeps(makeCmd(), nil, runDeps)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "review failed: boom")
 	})
@@ -592,12 +591,12 @@ categories:
 `), 0644))
 
 	prevConfig := flagConfig
-	prevBuildAIClient := buildAIClient
 	t.Cleanup(func() {
 		flagConfig = prevConfig
-		buildAIClient = prevBuildAIClient
 	})
 	flagConfig = cfgPath
+
+	deps := defaultReviewDeps()
 
 	makeCmd := func() *cobra.Command {
 		cmd := &cobra.Command{Use: "review"}
@@ -651,10 +650,11 @@ categories:
   maintainability: true
   vibe: true
 `), 0644))
-		buildAIClient = func(cfg *config.Config) (ai.AIClient, error) {
+		runDeps := deps
+		runDeps.buildAIClient = func(cfg *config.Config) (ai.AIClient, error) {
 			return nil, errors.New("boom")
 		}
-		err := runReview(makeCmd(), nil)
+		err := runReviewWithDeps(makeCmd(), nil, runDeps)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "boom")
 	})

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -62,11 +62,12 @@ Example:
 )
 
 var (
-	flagConfig     string
-	flagDryRun     bool
-	flagVerbose    bool
-	flagNoInline   bool
-	flagNoSummary  bool
+	flagConfig    string
+	flagDryRun    bool
+	flagVerbose   bool
+	flagNoInline  bool
+	flagNoSummary bool
+	getwd         = os.Getwd
 )
 
 func Execute() error {
@@ -185,13 +186,13 @@ func runDiff(cmd *cobra.Command, args []string) error {
 }
 
 func cwd() string {
-	dir, _ := os.Getwd()
+	dir, _ := getwd()
 	return dir
 }
 
 // detectGitInfo attempts to detect owner/repo from the local git config.
 func detectGitInfo() (owner, repo string, err error) {
-	dir, err := os.Getwd()
+	dir, err := getwd()
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1,0 +1,198 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetVersion(t *testing.T) {
+	SetVersion("1.2.3", "abc", "2026-03-20")
+	assert.Equal(t, "1.2.3", versionInfo.Version)
+	assert.Equal(t, "1.2.3", rootCmd.Version)
+}
+
+func TestRunConfigInitValidateDiffAndHelpers(t *testing.T) {
+	tmpDir := t.TempDir()
+	prevWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	t.Cleanup(func() {
+		_ = os.Chdir(prevWD)
+	})
+
+	stdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	require.NoError(t, runConfigInit(rootCmd, nil))
+	err = runConfigInit(rootCmd, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "surge.yaml already exists")
+
+	prevConfig := flagConfig
+	flagConfig = filepath.Join(tmpDir, "surge.yaml")
+	t.Cleanup(func() { flagConfig = prevConfig })
+
+	require.NoError(t, runConfigValidate(rootCmd, nil))
+	require.NoError(t, runDiff(rootCmd, nil))
+
+	require.NoError(t, w.Close())
+	os.Stdout = stdout
+
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+
+	output := buf.String()
+	assert.Contains(t, output, "Created surge.yaml")
+	assert.Contains(t, output, "Config is valid")
+	assert.Contains(t, output, "Diff command not yet implemented")
+	resolvedTmpDir, err := filepath.EvalSymlinks(tmpDir)
+	require.NoError(t, err)
+	assert.Equal(t, resolvedTmpDir, cwd())
+}
+
+func TestRunConfigInitWriteError(t *testing.T) {
+	tmpDir := t.TempDir()
+	prevWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	t.Cleanup(func() { _ = os.Chdir(prevWD) })
+	require.NoError(t, os.Chmod(tmpDir, 0500))
+	t.Cleanup(func() { _ = os.Chmod(tmpDir, 0755) })
+
+	err = runConfigInit(rootCmd, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to write config")
+}
+
+func TestDetectGitInfo(t *testing.T) {
+	t.Run("from git config", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitDir := filepath.Join(tmpDir, ".git")
+		require.NoError(t, os.Mkdir(gitDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(gitDir, "config"), []byte("[remote \"origin\"]\n\turl = https://github.com/octo/surge.git\n"), 0644))
+
+		prevWD, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
+		t.Cleanup(func() { _ = os.Chdir(prevWD) })
+
+		owner, repo, err := detectGitInfo()
+		require.NoError(t, err)
+		assert.Equal(t, "octo", owner)
+		assert.Equal(t, "surge", repo)
+	})
+
+	t.Run("from ssh git config", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitDir := filepath.Join(tmpDir, ".git")
+		require.NoError(t, os.Mkdir(gitDir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(gitDir, "config"), []byte("[remote \"origin\"]\n\turl = git@github.com:octo/surge.git\n"), 0644))
+
+		prevWD, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
+		t.Cleanup(func() { _ = os.Chdir(prevWD) })
+
+		owner, repo, err := detectGitInfo()
+		require.NoError(t, err)
+		assert.Equal(t, "octo", owner)
+		assert.Equal(t, "surge", repo)
+	})
+
+	t.Run("from env", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		prevWD, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
+		t.Cleanup(func() { _ = os.Chdir(prevWD) })
+
+		t.Setenv("GITHUB_REPOSITORY", "env-owner/env-repo")
+
+		owner, repo, err := detectGitInfo()
+		require.NoError(t, err)
+		assert.Equal(t, "env-owner", owner)
+		assert.Equal(t, "env-repo", repo)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		prevWD, err := os.Getwd()
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
+		t.Cleanup(func() { _ = os.Chdir(prevWD) })
+
+		t.Setenv("GITHUB_REPOSITORY", "invalid")
+
+		_, _, err = detectGitInfo()
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "could not detect git owner/repo")
+	})
+}
+
+func TestRunDiffConfigError(t *testing.T) {
+	prevConfig := flagConfig
+	flagConfig = filepath.Join(t.TempDir(), "missing.yaml")
+	t.Cleanup(func() { flagConfig = prevConfig })
+
+	err := runDiff(rootCmd, nil)
+	require.Error(t, err)
+}
+
+func TestDetectGitInfoGetwdError(t *testing.T) {
+	prev := getwd
+	getwd = func() (string, error) { return "", errors.New("boom") }
+	t.Cleanup(func() { getwd = prev })
+
+	_, _, err := detectGitInfo()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "boom")
+}
+
+func TestExecute(t *testing.T) {
+	oldArgs := os.Args
+	t.Cleanup(func() { os.Args = oldArgs })
+	rootCmd.SetArgs([]string{"--help"})
+	require.NoError(t, Execute())
+}
+
+func TestRunConfigValidateError(t *testing.T) {
+	prevConfig := flagConfig
+	flagConfig = filepath.Join(t.TempDir(), "missing.yaml")
+	t.Cleanup(func() { flagConfig = prevConfig })
+
+	err := runConfigValidate(rootCmd, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "config validation failed")
+}
+
+func TestRunConfigValidateInvalidConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "surge.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+ai:
+  provider: invalid
+output:
+  format: terminal
+contextDepth: diff-only
+categories:
+  security: true
+`), 0644))
+
+	prevConfig := flagConfig
+	flagConfig = cfgPath
+	t.Cleanup(func() { flagConfig = prevConfig })
+
+	err := runConfigValidate(rootCmd, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "config is invalid")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,35 @@ type envBinding struct {
 	env string
 }
 
+var (
+	configEnvBindings = []envBinding{
+		{key: "github.token", env: "SURGE_GITHUB_TOKEN"},
+		{key: "github.owner", env: "SURGE_GITHUB_OWNER"},
+		{key: "github.repo", env: "SURGE_GITHUB_REPO"},
+		{key: "github.prNumber", env: "SURGE_PR_NUMBER"},
+		{key: "ai.provider", env: "SURGE_AI_PROVIDER"},
+		{key: "ai.model", env: "SURGE_AI_MODEL"},
+		{key: "ai.baseUrl", env: "SURGE_AI_BASE_URL"},
+		{key: "ai.apiKey", env: "SURGE_AI_API_KEY"},
+		{key: "contextDepth", env: "SURGE_CONTEXT_DEPTH"},
+		{key: "output.format", env: "SURGE_OUTPUT"},
+		{key: "output.showStats", env: "SURGE_SHOW_STATS"},
+		{key: "maxInlineComments", env: "SURGE_MAX_INLINE"},
+		{key: "maxTokens", env: "SURGE_MAX_TOKENS"},
+		{key: "temperature", env: "SURGE_TEMPERATURE"},
+		{key: "dryRun", env: "SURGE_DRY_RUN"},
+		{key: "verbose", env: "SURGE_VERBOSE"},
+		{key: "noInline", env: "SURGE_NO_INLINE"},
+		{key: "noSummary", env: "SURGE_NO_SUMMARY"},
+		{key: "enablePRLabels", env: "SURGE_ENABLE_PR_LABELS"},
+		{key: "prLabelPrefix", env: "SURGE_PR_LABEL_PREFIX"},
+	}
+	bindEnv = func(v *viper.Viper, key string, envs ...string) error {
+		args := append([]string{key}, envs...)
+		return v.BindEnv(args...)
+	}
+)
+
 // Config represents the full surge configuration.
 type Config struct {
 	AI           AIConfig         `mapstructure:"ai"`
@@ -151,29 +180,8 @@ func configureConfigSources(v *viper.Viper, configPath string) {
 
 func bindEnvironment(v *viper.Viper) error {
 	var errs []error
-	for _, binding := range []envBinding{
-		{key: "github.token", env: "SURGE_GITHUB_TOKEN"},
-		{key: "github.owner", env: "SURGE_GITHUB_OWNER"},
-		{key: "github.repo", env: "SURGE_GITHUB_REPO"},
-		{key: "github.prNumber", env: "SURGE_PR_NUMBER"},
-		{key: "ai.provider", env: "SURGE_AI_PROVIDER"},
-		{key: "ai.model", env: "SURGE_AI_MODEL"},
-		{key: "ai.baseUrl", env: "SURGE_AI_BASE_URL"},
-		{key: "ai.apiKey", env: "SURGE_AI_API_KEY"},
-		{key: "contextDepth", env: "SURGE_CONTEXT_DEPTH"},
-		{key: "output.format", env: "SURGE_OUTPUT"},
-		{key: "output.showStats", env: "SURGE_SHOW_STATS"},
-		{key: "maxInlineComments", env: "SURGE_MAX_INLINE"},
-		{key: "maxTokens", env: "SURGE_MAX_TOKENS"},
-		{key: "temperature", env: "SURGE_TEMPERATURE"},
-		{key: "dryRun", env: "SURGE_DRY_RUN"},
-		{key: "verbose", env: "SURGE_VERBOSE"},
-		{key: "noInline", env: "SURGE_NO_INLINE"},
-		{key: "noSummary", env: "SURGE_NO_SUMMARY"},
-		{key: "enablePRLabels", env: "SURGE_ENABLE_PR_LABELS"},
-		{key: "prLabelPrefix", env: "SURGE_PR_LABEL_PREFIX"},
-	} {
-		if err := v.BindEnv(binding.key, binding.env); err != nil {
+	for _, binding := range configEnvBindings {
+		if err := bindEnv(v, binding.key, binding.env); err != nil {
 			errs = append(errs, fmt.Errorf("%s -> %s: %w", binding.key, binding.env, err))
 		}
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,11 +1,14 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoad_Defaults(t *testing.T) {
@@ -98,4 +101,81 @@ func TestExpandEnvVar(t *testing.T) {
 
 	result = expandEnv("${UNSET_VAR}")
 	assert.Equal(t, "${UNSET_VAR}", result)
+}
+
+func TestLoadReadConfigErrorAndEnvExpansion(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "surge.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("{"), 0644))
+
+	_, err := Load(configPath)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to read config")
+
+	assert.NoError(t, os.Setenv("BASE_URL_ENV", "http://example.com"))
+	defer func() { _ = os.Unsetenv("BASE_URL_ENV") }()
+
+	cfgPath := filepath.Join(tmpDir, "expanded.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+ai:
+  provider: litellm
+  baseUrl: "${BASE_URL_ENV}"
+categories:
+  security: true
+  performance: true
+  logic: true
+  maintainability: true
+  vibe: true
+output:
+  format: terminal
+contextDepth: diff-only
+`), 0644))
+	cfg, err := Load(cfgPath)
+	require.NoError(t, err)
+	assert.Equal(t, "http://example.com", cfg.AI.BaseURL)
+}
+
+func TestBindEnvironmentErrorAggregation(t *testing.T) {
+	prev := bindEnv
+	t.Cleanup(func() { bindEnv = prev })
+	bindEnv = func(v *viper.Viper, key string, envs ...string) error {
+		if key == "github.token" {
+			return errors.New("bind failed")
+		}
+		return nil
+	}
+
+	err := bindEnvironment(viper.New())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "github.token -> SURGE_GITHUB_TOKEN: bind failed")
+}
+
+func TestLoadUnmarshalError(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "surge.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+ai: "bad"
+`), 0644))
+
+	_, err := Load(configPath)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to unmarshal config")
+}
+
+func TestLoadMissingExplicitConfigPath(t *testing.T) {
+	_, err := Load(filepath.Join(t.TempDir(), "missing.yaml"))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to read config")
+}
+
+func TestLoadBindEnvironmentError(t *testing.T) {
+	prev := bindEnv
+	t.Cleanup(func() { bindEnv = prev })
+	bindEnv = func(v *viper.Viper, key string, envs ...string) error {
+		return errors.New("bind failed")
+	}
+
+	_, err := Load("")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to bind environment variables")
 }

--- a/internal/diff/parser_test.go
+++ b/internal/diff/parser_test.go
@@ -1,11 +1,16 @@
 package diff
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/AtomicWasTaken/surge/internal/model"
 	"github.com/stretchr/testify/assert"
 )
+
+type errReader struct{}
+
+func (errReader) Read(p []byte) (int, error) { return 0, errors.New("read failed") }
 
 func TestParser_ParseSimple(t *testing.T) {
 	diffContent := `diff --git a/main.go b/main.go
@@ -110,6 +115,43 @@ func TestFilterPaths_WithInclude(t *testing.T) {
 
 	result := FilterPaths(toFileChanges(files), include, exclude)
 	assert.Len(t, result, 2)
+}
+
+func TestParser_ParseEdgeCases(t *testing.T) {
+	p := NewParser()
+
+	diffContent := `diff --git a/old.go b/new.go
+similarity index 100%
+rename from old.go
+rename to new.go
+@@ -1 +1 @@
+-old
++new`
+	result, err := p.ParseFromString(diffContent)
+	assert.NoError(t, err)
+	assert.Len(t, result.Files, 1)
+	assert.Equal(t, "old.go", result.Files[0].Path)
+	assert.Equal(t, "modified", string(result.Files[0].Status))
+
+	result, err = p.ParseFromString("diff --git only-two-parts")
+	assert.NoError(t, err)
+	assert.Len(t, result.Files, 1)
+	assert.Equal(t, "", result.Files[0].Path)
+
+	_, err = p.Parse(errReader{})
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "error reading diff")
+
+	diffContent = `diff --git a/a.go b/a.go
+@@ -1 +1 @@
++new
+\ No newline at end of file
+diff --git a/b.go b/b.go
+@@ -1 +1 @@
++newer`
+	result, err = p.ParseFromString(diffContent)
+	assert.NoError(t, err)
+	assert.Len(t, result.Files, 2)
 }
 
 func toFileChanges(files []struct {

--- a/internal/github/github_client_test.go
+++ b/internal/github/github_client_test.go
@@ -3,14 +3,30 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/AtomicWasTaken/surge/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type errReadCloser struct{}
+
+func (errReadCloser) Read([]byte) (int, error) { return 0, errors.New("read failed") }
+func (errReadCloser) Close() error             { return nil }
 
 func TestDismissReviewUsesDocumentedPayload(t *testing.T) {
 	var (
@@ -82,4 +98,847 @@ func TestGitHubAPIError(t *testing.T) {
 	err := githubAPIError(http.StatusBadGateway, []byte(`{"message":"upstream failed"}`))
 	require.Error(t, err)
 	assert.Equal(t, `GitHub API error (502): {"message":"upstream failed"}`, err.Error())
+}
+
+func TestDoRequestAndParseJSONResponseErrors(t *testing.T) {
+	client := NewGitHubClient("test-token")
+
+	_, _, err := client.doRequest(context.Background(), http.MethodGet, "://bad-url", githubJSONAcceptHeader, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to create request")
+
+	var target map[string]string
+	err = parseJSONResponse([]byte(`{`), &target, "broken response")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to parse broken response")
+
+	_, _, err = client.doRequest(context.Background(), http.MethodPost, "http://example.com", githubJSONAcceptHeader, map[string]interface{}{"bad": math.NaN()})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to marshal body")
+
+	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("network down")
+	})}
+	_, _, err = client.doRequest(context.Background(), http.MethodGet, "http://example.com", githubJSONAcceptHeader, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "request failed")
+
+	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: http.StatusOK, Status: "200 OK", Body: errReadCloser{}, Header: make(http.Header)}, nil
+	})}
+	_, _, err = client.doRequest(context.Background(), http.MethodGet, "http://example.com", githubJSONAcceptHeader, nil)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to read response")
+}
+
+func TestGetPRSuccessAndErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       string
+		wantErr    string
+		wantNumber int
+	}{
+		{
+			name:   "success",
+			status: http.StatusOK,
+			body: `{
+				"number": 7,
+				"title": "Improve tests",
+				"body": "details",
+				"state": "open",
+				"user": {"login": "octocat"},
+				"base": {"ref": "main", "sha": "base"},
+				"head": {"ref": "feature", "sha": "head"},
+				"additions": 3,
+				"deletions": 1,
+				"changed_files": 2,
+				"html_url": "https://github.com/octo/surge/pull/7",
+				"created_at": "2026-03-19T10:00:00Z",
+				"updated_at": "2026-03-19T11:00:00Z"
+			}`,
+			wantNumber: 7,
+		},
+		{name: "not found", status: http.StatusNotFound, body: `{}`, wantErr: "PR not found: octo/surge#7"},
+		{name: "auth", status: http.StatusForbidden, body: `{}`, wantErr: "authentication failed"},
+		{name: "auth unauthorized", status: http.StatusUnauthorized, body: `{}`, wantErr: "authentication failed"},
+		{name: "other", status: http.StatusBadGateway, body: `boom`, wantErr: "GitHub API error (502): boom"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			client := NewGitHubClient("test-token")
+			client.apiURL = server.URL
+
+			pr, err := client.GetPR(context.Background(), "octo", "surge", 7)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, pr)
+			assert.Equal(t, tt.wantNumber, pr.Number)
+			assert.Equal(t, "Improve tests", pr.Title)
+			assert.Equal(t, "octocat", pr.Author)
+			assert.Equal(t, "main", pr.BaseRef)
+			assert.Equal(t, "feature", pr.HeadRef)
+			assert.WithinDuration(t, time.Date(2026, 3, 19, 10, 0, 0, 0, time.UTC), pr.CreatedAt, 0)
+		})
+	}
+
+	t.Run("parse error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{`))
+		}))
+		defer server.Close()
+
+		client := NewGitHubClient("test-token")
+		client.apiURL = server.URL
+
+		_, err := client.GetPR(context.Background(), "octo", "surge", 7)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed to parse PR response")
+	})
+}
+
+func TestGetDiffAndFiles(t *testing.T) {
+	t.Run("diff success and error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Accept") == githubDiffAcceptHeader {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("diff --git a.go b.go"))
+				return
+			}
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte("boom"))
+		}))
+		defer server.Close()
+
+		client := NewGitHubClient("test-token")
+		client.apiURL = server.URL
+
+		diff, err := client.GetDiff(context.Background(), "octo", "surge", 1)
+		require.NoError(t, err)
+		assert.Equal(t, "diff --git a.go b.go", diff)
+	})
+
+	t.Run("diff error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte("boom"))
+		}))
+		defer server.Close()
+
+		client := NewGitHubClient("test-token")
+		client.apiURL = server.URL
+
+		_, err := client.GetDiff(context.Background(), "octo", "surge", 1)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "GitHub API error (502): boom")
+	})
+
+	t.Run("files success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[
+				{"filename":"a.go","status":"modified","additions":2,"deletions":1,"patch":"@@"},
+				{"filename":"b.go","status":"deleted","additions":0,"deletions":5,"patch":""}
+			]`))
+		}))
+		defer server.Close()
+
+		client := NewGitHubClient("test-token")
+		client.apiURL = server.URL
+
+		files, err := client.GetFiles(context.Background(), "octo", "surge", 1)
+		require.NoError(t, err)
+		require.Len(t, files, 2)
+		assert.Equal(t, model.FileStatusModified, files[0].Status)
+		assert.Equal(t, model.FileStatusDeleted, files[1].Status)
+	})
+
+	t.Run("files error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte("boom"))
+		}))
+		defer server.Close()
+
+		client := NewGitHubClient("test-token")
+		client.apiURL = server.URL
+
+		_, err := client.GetFiles(context.Background(), "octo", "surge", 1)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "GitHub API error (502): boom")
+	})
+
+	t.Run("files parse error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{`))
+		}))
+		defer server.Close()
+
+		client := NewGitHubClient("test-token")
+		client.apiURL = server.URL
+
+		_, err := client.GetFiles(context.Background(), "octo", "surge", 1)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed to parse files response")
+	})
+}
+
+func TestGetFileContentErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		body    string
+		wantErr string
+	}{
+		{name: "not found", status: http.StatusNotFound, body: `{}`, wantErr: "file not found: path.go at ref"},
+		{name: "api error", status: http.StatusBadGateway, body: `boom`, wantErr: "GitHub API error (502): boom"},
+		{name: "decode error", status: http.StatusOK, body: `{"content":"not-base64","encoding":"base64"}`, wantErr: "failed to decode file content"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			client := NewGitHubClient("test-token")
+			client.apiURL = server.URL
+
+			_, err := client.GetFileContent(context.Background(), "octo", "surge", "path.go", "ref")
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+
+	t.Run("parse error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{`))
+		}))
+		defer server.Close()
+
+		client := NewGitHubClient("test-token")
+		client.apiURL = server.URL
+
+		_, err := client.GetFileContent(context.Background(), "octo", "surge", "path.go", "ref")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed to parse file response")
+	})
+}
+
+func TestReviewAndCommentOperations(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		method   string
+		status   int
+		body     string
+		run      func(*GitHubClient) error
+		wantErr  string
+		wantBody string
+	}{
+		{
+			name:   "post review success",
+			path:   "/repos/octo/surge/pulls/1/reviews",
+			method: http.MethodPost,
+			status: http.StatusCreated,
+			body:   `{}`,
+			run: func(c *GitHubClient) error {
+				return c.PostReview(context.Background(), "octo", "surge", 1, &model.ReviewInput{
+					Event: "COMMENT",
+					Body:  "summary",
+					Comments: []model.ReviewComment{
+						{Path: "a.go", Position: 2, Body: "inline"},
+					},
+				})
+			},
+			wantBody: `"comments":[{"body":"inline","path":"a.go","position":2}]`,
+		},
+		{
+			name:   "post review success ok",
+			path:   "/repos/octo/surge/pulls/1/reviews",
+			method: http.MethodPost,
+			status: http.StatusOK,
+			body:   `{}`,
+			run: func(c *GitHubClient) error {
+				return c.PostReview(context.Background(), "octo", "surge", 1, &model.ReviewInput{Event: "COMMENT", Body: "summary"})
+			},
+			wantBody: `"event":"COMMENT"`,
+		},
+		{
+			name:   "post review stale",
+			path:   "/repos/octo/surge/pulls/1/reviews",
+			method: http.MethodPost,
+			status: http.StatusUnprocessableEntity,
+			body:   `{}`,
+			run: func(c *GitHubClient) error {
+				return c.PostReview(context.Background(), "octo", "surge", 1, &model.ReviewInput{Event: "COMMENT", Body: "summary"})
+			},
+			wantErr: "review position is stale",
+		},
+		{
+			name:   "post comment success",
+			path:   "/repos/octo/surge/issues/1/comments",
+			method: http.MethodPost,
+			status: http.StatusCreated,
+			body:   `{}`,
+			run: func(c *GitHubClient) error {
+				return c.PostComment(context.Background(), "octo", "surge", 1, "hello")
+			},
+			wantBody: `"body":"hello"`,
+		},
+		{
+			name:   "post comment error",
+			path:   "/repos/octo/surge/issues/1/comments",
+			method: http.MethodPost,
+			status: http.StatusBadGateway,
+			body:   `boom`,
+			run: func(c *GitHubClient) error {
+				return c.PostComment(context.Background(), "octo", "surge", 1, "hello")
+			},
+			wantErr: "GitHub API error (502): boom",
+		},
+		{
+			name:   "post review generic error",
+			path:   "/repos/octo/surge/pulls/1/reviews",
+			method: http.MethodPost,
+			status: http.StatusUnauthorized,
+			body:   `denied`,
+			run: func(c *GitHubClient) error {
+				return c.PostReview(context.Background(), "octo", "surge", 1, &model.ReviewInput{Event: "COMMENT", Body: "summary"})
+			},
+			wantErr: "GitHub API error (401): denied",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotBody string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, tt.method, r.Method)
+				assert.Equal(t, tt.path, r.URL.Path)
+				data, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+				gotBody = string(data)
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			client := NewGitHubClient("test-token")
+			client.apiURL = server.URL
+
+			err := tt.run(client)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Contains(t, gotBody, tt.wantBody)
+		})
+	}
+}
+
+func TestListAndDeleteOperations(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		method  string
+		status  int
+		body    string
+		run     func(*GitHubClient) error
+		wantErr string
+	}{
+		{
+			name:   "list comments",
+			path:   "/repos/octo/surge/issues/1/comments",
+			method: http.MethodGet,
+			status: http.StatusOK,
+			body:   `[{"id":1,"body":"hi","user":{"login":"bot","type":"Bot"},"created_at":"now"}]`,
+			run: func(c *GitHubClient) error {
+				comments, err := c.ListComments(context.Background(), "octo", "surge", 1)
+				if err == nil {
+					require.Len(t, comments, 1)
+					assert.True(t, comments[0].IsBot)
+				}
+				return err
+			},
+		},
+		{
+			name:   "list comments parse error",
+			path:   "/repos/octo/surge/issues/1/comments",
+			method: http.MethodGet,
+			status: http.StatusOK,
+			body:   `{`,
+			run: func(c *GitHubClient) error {
+				_, err := c.ListComments(context.Background(), "octo", "surge", 1)
+				return err
+			},
+			wantErr: "failed to parse comments",
+		},
+		{
+			name:   "list comments status error",
+			path:   "/repos/octo/surge/issues/1/comments",
+			method: http.MethodGet,
+			status: http.StatusBadGateway,
+			body:   `boom`,
+			run: func(c *GitHubClient) error {
+				_, err := c.ListComments(context.Background(), "octo", "surge", 1)
+				return err
+			},
+			wantErr: "GitHub API error (502): boom",
+		},
+		{
+			name:   "delete comment",
+			path:   "/repos/octo/surge/issues/comments/9",
+			method: http.MethodDelete,
+			status: http.StatusNoContent,
+			body:   ``,
+			run: func(c *GitHubClient) error {
+				return c.DeleteComment(context.Background(), "octo", "surge", 9)
+			},
+		},
+		{
+			name:   "delete comment error",
+			path:   "/repos/octo/surge/issues/comments/9",
+			method: http.MethodDelete,
+			status: http.StatusBadGateway,
+			body:   ``,
+			run: func(c *GitHubClient) error {
+				return c.DeleteComment(context.Background(), "octo", "surge", 9)
+			},
+			wantErr: "GitHub API error (502)",
+		},
+		{
+			name:   "list reviews parse error",
+			path:   "/repos/octo/surge/pulls/1/reviews",
+			method: http.MethodGet,
+			status: http.StatusOK,
+			body:   `{`,
+			run: func(c *GitHubClient) error {
+				_, err := c.ListReviews(context.Background(), "octo", "surge", 1)
+				return err
+			},
+			wantErr: "failed to parse reviews",
+		},
+		{
+			name:   "list reviews status error",
+			path:   "/repos/octo/surge/pulls/1/reviews",
+			method: http.MethodGet,
+			status: http.StatusBadGateway,
+			body:   `boom`,
+			run: func(c *GitHubClient) error {
+				_, err := c.ListReviews(context.Background(), "octo", "surge", 1)
+				return err
+			},
+			wantErr: "GitHub API error (502): boom",
+		},
+		{
+			name:   "list reviews",
+			path:   "/repos/octo/surge/pulls/1/reviews",
+			method: http.MethodGet,
+			status: http.StatusOK,
+			body:   `[{"id":2,"body":"summary","state":"COMMENTED","user":{"login":"bot","type":"Bot"},"created_at":"now"}]`,
+			run: func(c *GitHubClient) error {
+				reviews, err := c.ListReviews(context.Background(), "octo", "surge", 1)
+				if err == nil {
+					require.Len(t, reviews, 1)
+					assert.True(t, reviews[0].IsBot)
+				}
+				return err
+			},
+		},
+		{
+			name:   "delete review",
+			path:   "/repos/octo/surge/pulls/1/reviews/2",
+			method: http.MethodDelete,
+			status: http.StatusNoContent,
+			body:   `{}`,
+			run: func(c *GitHubClient) error {
+				return c.DeleteReview(context.Background(), "octo", "surge", 1, 2)
+			},
+		},
+		{
+			name:   "delete review ok",
+			path:   "/repos/octo/surge/pulls/1/reviews/2",
+			method: http.MethodDelete,
+			status: http.StatusOK,
+			body:   `{}`,
+			run: func(c *GitHubClient) error {
+				return c.DeleteReview(context.Background(), "octo", "surge", 1, 2)
+			},
+		},
+		{
+			name:   "delete review error",
+			path:   "/repos/octo/surge/pulls/1/reviews/2",
+			method: http.MethodDelete,
+			status: http.StatusBadGateway,
+			body:   `boom`,
+			run: func(c *GitHubClient) error {
+				return c.DeleteReview(context.Background(), "octo", "surge", 1, 2)
+			},
+			wantErr: "GitHub API error (502): boom",
+		},
+		{
+			name:   "delete review comment",
+			path:   "/repos/octo/surge/pulls/comments/3",
+			method: http.MethodDelete,
+			status: http.StatusNoContent,
+			body:   `{}`,
+			run: func(c *GitHubClient) error {
+				return c.DeleteReviewComment(context.Background(), "octo", "surge", 3)
+			},
+		},
+		{
+			name:   "delete review comment error",
+			path:   "/repos/octo/surge/pulls/comments/3",
+			method: http.MethodDelete,
+			status: http.StatusBadGateway,
+			body:   `boom`,
+			run: func(c *GitHubClient) error {
+				return c.DeleteReviewComment(context.Background(), "octo", "surge", 3)
+			},
+			wantErr: "GitHub API error (502): boom",
+		},
+		{
+			name:   "list review comments",
+			path:   "/repos/octo/surge/pulls/1/reviews/2/comments",
+			method: http.MethodGet,
+			status: http.StatusOK,
+			body:   `[{"id":3,"body":"inline"}]`,
+			run: func(c *GitHubClient) error {
+				comments, err := c.ListReviewComments(context.Background(), "octo", "surge", 1, 2)
+				if err == nil {
+					require.Len(t, comments, 1)
+					assert.Equal(t, int64(3), comments[0].ID)
+				}
+				return err
+			},
+		},
+		{
+			name:   "list review comments parse error",
+			path:   "/repos/octo/surge/pulls/1/reviews/2/comments",
+			method: http.MethodGet,
+			status: http.StatusOK,
+			body:   `{`,
+			run: func(c *GitHubClient) error {
+				_, err := c.ListReviewComments(context.Background(), "octo", "surge", 1, 2)
+				return err
+			},
+			wantErr: "failed to parse review comments",
+		},
+		{
+			name:   "list review comments status error",
+			path:   "/repos/octo/surge/pulls/1/reviews/2/comments",
+			method: http.MethodGet,
+			status: http.StatusBadGateway,
+			body:   `boom`,
+			run: func(c *GitHubClient) error {
+				_, err := c.ListReviewComments(context.Background(), "octo", "surge", 1, 2)
+				return err
+			},
+			wantErr: "GitHub API error (502): boom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, tt.method, r.Method)
+				assert.Equal(t, tt.path, r.URL.Path)
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			client := NewGitHubClient("test-token")
+			client.apiURL = server.URL
+
+			err := tt.run(client)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestLabelOperations(t *testing.T) {
+	t.Run("list add remove labels", func(t *testing.T) {
+		var callCount int
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			switch callCount {
+			case 1:
+				assert.Equal(t, "/repos/octo/surge/issues/1/labels", r.URL.Path)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`[{"name":"surge:logic"},{"name":""}]`))
+			case 2:
+				assert.Equal(t, http.MethodPost, r.Method)
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(`[]`))
+			case 3:
+				assert.Equal(t, "/repos/octo/surge/issues/1/labels/surge:logic", r.URL.EscapedPath())
+				w.WriteHeader(http.StatusNotFound)
+			default:
+				t.Fatalf("unexpected request %d", callCount)
+			}
+		}))
+		defer server.Close()
+
+		client := NewGitHubClient("test-token")
+		client.apiURL = server.URL
+
+		labels, err := client.ListLabels(context.Background(), "octo", "surge", 1)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"surge:logic"}, labels)
+
+		require.NoError(t, client.AddLabels(context.Background(), "octo", "surge", 1, []string{"surge:logic"}))
+		require.NoError(t, client.RemoveLabel(context.Background(), "octo", "surge", 1, "surge:logic"))
+	})
+
+	t.Run("label errors and alt statuses", func(t *testing.T) {
+		var callCount int
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			switch callCount {
+			case 1:
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{`))
+			case 2:
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`[]`))
+			case 3:
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`[]`))
+			case 4:
+				w.WriteHeader(http.StatusBadGateway)
+				_, _ = w.Write([]byte(`boom`))
+			default:
+				t.Fatalf("unexpected request %d", callCount)
+			}
+		}))
+		defer server.Close()
+
+		client := NewGitHubClient("test-token")
+		client.apiURL = server.URL
+
+		_, err := client.ListLabels(context.Background(), "octo", "surge", 1)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed to parse labels")
+
+		require.NoError(t, client.AddLabels(context.Background(), "octo", "surge", 1, []string{"a"}))
+		require.NoError(t, client.RemoveLabel(context.Background(), "octo", "surge", 1, "a"))
+
+		err = client.AddLabels(context.Background(), "octo", "surge", 1, []string{"a"})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "GitHub API error (502): boom")
+	})
+
+	t.Run("add labels empty short-circuits", func(t *testing.T) {
+		client := NewGitHubClient("test-token")
+		require.NoError(t, client.AddLabels(context.Background(), "octo", "surge", 1, nil))
+	})
+
+	t.Run("remove label alternate statuses and error", func(t *testing.T) {
+		t.Run("ok status", func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+			client := NewGitHubClient("test-token")
+			client.apiURL = server.URL
+			require.NoError(t, client.RemoveLabel(context.Background(), "octo", "surge", 1, "a"))
+		})
+
+		t.Run("error status", func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadGateway)
+				_, _ = w.Write([]byte(`boom`))
+			}))
+			defer server.Close()
+			client := NewGitHubClient("test-token")
+			client.apiURL = server.URL
+			err := client.RemoveLabel(context.Background(), "octo", "surge", 1, "a")
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "GitHub API error (502): boom")
+		})
+	})
+
+	t.Run("upsert label create then patch", func(t *testing.T) {
+		var methods []string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			methods = append(methods, r.Method)
+			if len(methods) == 1 {
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				_, _ = w.Write([]byte(`exists`))
+				return
+			}
+			assert.Equal(t, "/repos/octo/surge/labels/surge:logic", r.URL.EscapedPath())
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		defer server.Close()
+
+		client := NewGitHubClient("test-token")
+		client.apiURL = server.URL
+
+		err := client.UpsertLabel(context.Background(), "octo", "surge", "surge:logic", "ffffff", "desc")
+		require.NoError(t, err)
+		assert.Equal(t, []string{http.MethodPost, http.MethodPatch}, methods)
+	})
+
+	t.Run("upsert label create success and failures", func(t *testing.T) {
+		t.Run("create success", func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			defer server.Close()
+			client := NewGitHubClient("test-token")
+			client.apiURL = server.URL
+			require.NoError(t, client.UpsertLabel(context.Background(), "octo", "surge", "surge:logic", "ffffff", "desc"))
+		})
+
+		t.Run("create hard error", func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadGateway)
+				_, _ = w.Write([]byte(`boom`))
+			}))
+			defer server.Close()
+			client := NewGitHubClient("test-token")
+			client.apiURL = server.URL
+			err := client.UpsertLabel(context.Background(), "octo", "surge", "surge:logic", "ffffff", "desc")
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "GitHub API error (502): boom")
+		})
+
+		t.Run("patch error", func(t *testing.T) {
+			var callCount int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				callCount++
+				if callCount == 1 {
+					w.WriteHeader(http.StatusUnprocessableEntity)
+					_, _ = w.Write([]byte(`exists`))
+					return
+				}
+				w.WriteHeader(http.StatusBadGateway)
+				_, _ = w.Write([]byte(`boom`))
+			}))
+			defer server.Close()
+			client := NewGitHubClient("test-token")
+			client.apiURL = server.URL
+			err := client.UpsertLabel(context.Background(), "octo", "surge", "surge:logic", "ffffff", "desc")
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "GitHub API error (502): boom")
+		})
+	})
+}
+
+func TestDismissReviewError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`boom`))
+	}))
+	defer server.Close()
+
+	client := NewGitHubClient("test-token")
+	client.apiURL = server.URL
+
+	err := client.DismissReview(context.Background(), "octo", "surge", 1, 2, "msg")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "GitHub API error (502): boom")
+}
+
+func TestGitHubClientWrapperRequestErrors(t *testing.T) {
+	client := NewGitHubClient("test-token")
+	client.apiURL = "://bad"
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{"get pr", func() error { _, err := client.GetPR(context.Background(), "o", "r", 1); return err }},
+		{"get diff", func() error { _, err := client.GetDiff(context.Background(), "o", "r", 1); return err }},
+		{"get files", func() error { _, err := client.GetFiles(context.Background(), "o", "r", 1); return err }},
+		{"get file content", func() error { _, err := client.GetFileContent(context.Background(), "o", "r", "p", "ref"); return err }},
+		{"post review", func() error { return client.PostReview(context.Background(), "o", "r", 1, &model.ReviewInput{}) }},
+		{"post comment", func() error { return client.PostComment(context.Background(), "o", "r", 1, "body") }},
+		{"list comments", func() error { _, err := client.ListComments(context.Background(), "o", "r", 1); return err }},
+		{"delete comment", func() error { return client.DeleteComment(context.Background(), "o", "r", 1) }},
+		{"list reviews", func() error { _, err := client.ListReviews(context.Background(), "o", "r", 1); return err }},
+		{"delete review", func() error { return client.DeleteReview(context.Background(), "o", "r", 1, 2) }},
+		{"dismiss review", func() error { return client.DismissReview(context.Background(), "o", "r", 1, 2, "msg") }},
+		{"list review comments", func() error { _, err := client.ListReviewComments(context.Background(), "o", "r", 1, 2); return err }},
+		{"delete review comment", func() error { return client.DeleteReviewComment(context.Background(), "o", "r", 1) }},
+		{"list labels", func() error { _, err := client.ListLabels(context.Background(), "o", "r", 1); return err }},
+		{"add labels", func() error { return client.AddLabels(context.Background(), "o", "r", 1, []string{"a"}) }},
+		{"remove label", func() error { return client.RemoveLabel(context.Background(), "o", "r", 1, "a") }},
+		{"upsert label", func() error { return client.UpsertLabel(context.Background(), "o", "r", "a", "fff", "d") }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run()
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "failed to create request")
+		})
+	}
+}
+
+func TestListLabelsStatusErrorAndUpsertPatchRequestError(t *testing.T) {
+	t.Run("list labels non-200", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte(`boom`))
+		}))
+		defer server.Close()
+
+		client := NewGitHubClient("test-token")
+		client.apiURL = server.URL
+		_, err := client.ListLabels(context.Background(), "octo", "surge", 1)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "GitHub API error (502): boom")
+	})
+
+	t.Run("upsert label patch request error", func(t *testing.T) {
+		client := NewGitHubClient("test-token")
+		client.apiURL = "http://example.com"
+		call := 0
+		client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			call++
+			if call == 1 {
+				return &http.Response{
+					StatusCode: http.StatusUnprocessableEntity,
+					Status:     "422 Unprocessable Entity",
+					Body:       io.NopCloser(strings.NewReader("exists")),
+					Header:     make(http.Header),
+				}, nil
+			}
+			return nil, errors.New("network down")
+		})}
+
+		err := client.UpsertLabel(context.Background(), "octo", "surge", "surge:logic", "ffffff", "desc")
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "network down")
+	})
 }

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -10,6 +10,11 @@ import (
 // JSONOutput renders review results as structured JSON.
 type JSONOutput struct{}
 
+var (
+	jsonMarshalIndent = json.MarshalIndent
+	jsonMarshal       = json.Marshal
+)
+
 // NewJSONOutput creates a new JSON output renderer.
 func NewJSONOutput() *JSONOutput {
 	return &JSONOutput{}
@@ -38,7 +43,7 @@ func (j *JSONOutput) Render(result *model.ReviewResult) string {
 		},
 	}
 
-	data, err := json.MarshalIndent(out, "", "  ")
+	data, err := jsonMarshalIndent(out, "", "  ")
 	if err != nil {
 		return fmt.Sprintf(`{"error": "failed to marshal JSON: %v"}`, err)
 	}
@@ -48,7 +53,7 @@ func (j *JSONOutput) Render(result *model.ReviewResult) string {
 
 // RenderCompact renders the review result as compact JSON (single line).
 func (j *JSONOutput) RenderCompact(result *model.ReviewResult) string {
-	data, err := json.Marshal(result)
+	data, err := jsonMarshal(result)
 	if err != nil {
 		return fmt.Sprintf(`{"error": "failed to marshal JSON: %v"}`, err)
 	}

--- a/internal/output/json_test.go
+++ b/internal/output/json_test.go
@@ -1,0 +1,72 @@
+package output
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/AtomicWasTaken/surge/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJSONOutputRenderAndCompact(t *testing.T) {
+	result := &model.ReviewResult{
+		Summary: "Review summary",
+		VibeCheck: model.VibeCheck{
+			Score:   7,
+			Verdict: "Reasonable",
+			Flags:   []string{"flag-a"},
+		},
+		Findings: []model.Finding{
+			{Severity: model.SeverityLow, Title: "Minor issue", Body: "Details"},
+		},
+		Warnings:        []string{"partial context"},
+		Recommendations: []string{"add tests"},
+		Approve:         true,
+		Stats: model.ReviewStats{
+			FilesReviewed: 2,
+			TokensIn:      10,
+			TokensOut:     20,
+			Duration:      1.25,
+		},
+	}
+
+	out := NewJSONOutput()
+	rendered := out.Render(result)
+	compact := out.RenderCompact(result)
+
+	assert.Contains(t, rendered, `"version": "1.0"`)
+	assert.Contains(t, rendered, `"summary": "Review summary"`)
+	assert.Contains(t, rendered, `"duration": "1.2s"`)
+	assert.Contains(t, compact, `"summary":"Review summary"`)
+	assert.NotContains(t, compact, "\n")
+}
+
+func TestJSONOutputRenderCompactMarshalError(t *testing.T) {
+	result := &model.ReviewResult{
+		Warnings: []string{"contains invalid utf8: " + string([]byte{0xff})},
+	}
+
+	rendered := NewJSONOutput().RenderCompact(result)
+	assert.True(t, strings.HasPrefix(rendered, "{"))
+}
+
+func TestJSONOutputMarshalFailures(t *testing.T) {
+	prevIndent := jsonMarshalIndent
+	prevMarshal := jsonMarshal
+	t.Cleanup(func() {
+		jsonMarshalIndent = prevIndent
+		jsonMarshal = prevMarshal
+	})
+
+	jsonMarshalIndent = func(v interface{}, prefix, indent string) ([]byte, error) {
+		return nil, errors.New("indent failed")
+	}
+	jsonMarshal = func(v interface{}) ([]byte, error) {
+		return nil, errors.New("marshal failed")
+	}
+
+	out := NewJSONOutput()
+	assert.Contains(t, out.Render(&model.ReviewResult{}), `failed to marshal JSON: indent failed`)
+	assert.Contains(t, out.RenderCompact(&model.ReviewResult{}), `failed to marshal JSON: marshal failed`)
+}

--- a/internal/output/markdown_test.go
+++ b/internal/output/markdown_test.go
@@ -209,6 +209,72 @@ func TestSanitizeBlockquote(t *testing.T) {
 	}
 }
 
+func TestMarkdownHelpers(t *testing.T) {
+	assertContains(t, ScopedCommentMarker("SURGE", CommentScopeInline), "SURGE_INLINE")
+	assertContains(t, CommentMarker("SURGE"), "SURGE")
+	markers := ScopedCommentMarkers("SURGE")
+	if len(markers) != 2 {
+		t.Fatalf("expected 2 scoped markers")
+	}
+	assertContains(t, SeverityEmoji(model.SeverityCritical), "🔴")
+	assertContains(t, SeverityEmoji(model.SeverityHigh), "🟠")
+	assertContains(t, SeverityEmoji(model.SeverityMedium), "🟡")
+	assertContains(t, SeverityEmoji(model.SeverityLow), "🔵")
+	assertContains(t, SeverityEmoji(model.SeverityInfo), "⚪")
+	assertContains(t, riskEmoji("high"), "🔴")
+	assertContains(t, riskEmoji("medium"), "🟡")
+	assertContains(t, riskEmoji("low"), "🟢")
+	assertContains(t, severityLabel(model.SeverityCritical), "CRITICAL")
+	assertContains(t, severityLabel(model.SeverityHigh), "HIGH")
+	assertContains(t, severityLabel(model.SeverityMedium), "MEDIUM")
+	assertContains(t, severityLabel(model.SeverityLow), "LOW")
+	assertContains(t, severityLabel(model.SeverityInfo), "INFO")
+	assertContains(t, vibeBar(-1), "░")
+	assertContains(t, vibeBar(12), "█")
+}
+
+func TestRenderSummaryAllSeveritiesAndLocationWithoutLine(t *testing.T) {
+	out := NewMarkdownOutput("SURGE")
+	result := &model.ReviewResult{
+		Summary: "Summary.",
+		Findings: []model.Finding{
+			{Severity: model.SeverityCritical, Category: model.CategorySecurity, File: "a.go", Title: "Critical", Body: "Body"},
+			{Severity: model.SeverityInfo, Category: model.CategoryMaintainability, File: "b.go", Title: "Info", Body: "Body"},
+		},
+		VibeCheck: model.VibeCheck{Score: 1, Verdict: "Bad"},
+	}
+
+	rendered := out.RenderSummary(result)
+	assertContains(t, rendered, "🔴 1 critical")
+	assertContains(t, rendered, "⚪ 1 info")
+	assertContains(t, rendered, "<code>a.go</code>")
+	assertContains(t, rendered, "<code>b.go</code>")
+}
+
+func TestRenderSummaryWarningsMediumFlagsAndRecommendations(t *testing.T) {
+	out := NewMarkdownOutput("SURGE")
+	result := &model.ReviewResult{
+		Summary:  "Summary.",
+		Warnings: []string{"warning one", "warning two"},
+		FilesOverview: []model.FileOverview{
+			{Path: "a.go", Changes: "change", Risk: "medium"},
+		},
+		Findings: []model.Finding{
+			{Severity: model.SeverityMedium, Category: model.CategoryLogic, File: "a.go", Line: 2, Title: "Medium", Body: "Body"},
+		},
+		VibeCheck:       model.VibeCheck{Score: 5, Verdict: "Verdict", Flags: []string{"flag-a", "flag-b"}},
+		Recommendations: []string{"one", "two"},
+	}
+
+	rendered := out.RenderSummary(result)
+	assertContains(t, rendered, "🟡 1 medium")
+	assertContains(t, rendered, "⚠️ **Warnings**")
+	assertContains(t, rendered, "- warning one")
+	assertContains(t, rendered, "Flags:** `flag-a`, `flag-b`")
+	assertContains(t, rendered, "- [ ] one")
+	assertContains(t, rendered, "- [ ] two")
+}
+
 func assertContains(t *testing.T, text, want string) {
 	t.Helper()
 	if !strings.Contains(text, want) {

--- a/internal/output/terminal_test.go
+++ b/internal/output/terminal_test.go
@@ -1,0 +1,206 @@
+package output
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/AtomicWasTaken/surge/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTerminalOutputRender(t *testing.T) {
+	out := NewTerminalOutput()
+	result := &model.ReviewResult{
+		Summary:  "This summary should wrap onto multiple lines for the renderer to exercise the wrapping path.",
+		Warnings: []string{"partial context"},
+		Findings: []model.Finding{
+			{
+				Severity:   model.SeverityCritical,
+				Title:      "Critical issue",
+				File:       "a.go",
+				Line:       10,
+				Body:       "Detailed explanation for a critical issue in the change.",
+				Suggestion: "Use safe output \x1b[31mwithout control bytes\non one line.",
+			},
+			{
+				Severity: model.SeverityInfo,
+				Title:    "Informational note",
+				Body:     "No file attached.",
+			},
+		},
+		VibeCheck: model.VibeCheck{
+			Score:   8,
+			Verdict: "Mostly fine",
+			Flags:   []string{"generated"},
+		},
+		Stats: model.ReviewStats{
+			FilesReviewed: 3,
+			TokensIn:      100,
+			TokensOut:     50,
+			Duration:      2.5,
+		},
+		Approve: true,
+	}
+
+	stdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	out.Render(result)
+
+	require.NoError(t, w.Close())
+	os.Stdout = stdout
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+
+	rendered := buf.String()
+	assert.Contains(t, rendered, "Warnings")
+	assert.Contains(t, rendered, "Findings")
+	assert.Contains(t, rendered, "Critical issue")
+	assert.Contains(t, rendered, "Fix: Use safe output")
+	assert.Contains(t, rendered, "Vibe Check")
+	assert.Contains(t, rendered, "Flags: `generated`")
+	assert.Contains(t, rendered, "✅ Approve")
+}
+
+func TestRenderVibeCheckClampsScoreAndOmitsFlagsWhenEmpty(t *testing.T) {
+	out := NewTerminalOutput()
+
+	stdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	out.renderVibeCheck(model.VibeCheck{Score: -3, Verdict: "Bad"})
+	out.renderVibeCheck(model.VibeCheck{Score: 15, Verdict: "Great"})
+
+	require.NoError(t, w.Close())
+	os.Stdout = stdout
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+
+	rendered := buf.String()
+	assert.Contains(t, rendered, "0/10")
+	assert.Contains(t, rendered, "10/10")
+	assert.NotContains(t, rendered, "Flags:")
+}
+
+func TestWrapTextAndSanitizeHelpers(t *testing.T) {
+	assert.Equal(t, []string{""}, wrapText("", 10))
+	assert.Equal(t, []string{"one", "two"}, wrapText("one two", 4))
+	assert.Equal(t, "hello world  next", sanitizeTerminalText("hello\x1b[31m world\t\nnext"))
+}
+
+func TestRenderErrorAndWarning(t *testing.T) {
+	stdout := os.Stdout
+	stderr := os.Stderr
+	outR, outW, err := os.Pipe()
+	require.NoError(t, err)
+	errR, errW, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = outW
+	os.Stderr = errW
+
+	RenderWarning("careful")
+	RenderError("broken")
+
+	require.NoError(t, outW.Close())
+	require.NoError(t, errW.Close())
+	os.Stdout = stdout
+	os.Stderr = stderr
+
+	var outBuf, errBuf bytes.Buffer
+	_, err = io.Copy(&outBuf, outR)
+	require.NoError(t, err)
+	_, err = io.Copy(&errBuf, errR)
+	require.NoError(t, err)
+	require.NoError(t, outR.Close())
+	require.NoError(t, errR.Close())
+
+	assert.Contains(t, outBuf.String(), "WARNING:")
+	assert.Contains(t, errBuf.String(), "ERROR:")
+}
+
+func TestTerminalRenderWithoutFindingsAndLowVibe(t *testing.T) {
+	out := NewTerminalOutput()
+	result := &model.ReviewResult{
+		Summary: "Short summary.",
+		VibeCheck: model.VibeCheck{
+			Score:   3,
+			Verdict: "Rough",
+		},
+		Stats:   model.ReviewStats{},
+		Approve: false,
+	}
+
+	stdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	out.Render(result)
+	require.NoError(t, w.Close())
+	os.Stdout = stdout
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	rendered := buf.String()
+	assert.NotContains(t, rendered, "Findings\n")
+	assert.Contains(t, rendered, "❌ Request Changes")
+}
+
+func TestTerminalRenderFindingWithoutLine(t *testing.T) {
+	out := NewTerminalOutput()
+	result := &model.ReviewResult{
+		Summary: "Summary.",
+		Findings: []model.Finding{
+			{Severity: model.SeverityLow, Title: "Low issue", File: "a.go", Body: "Body"},
+		},
+		VibeCheck: model.VibeCheck{Score: 6, Verdict: "Okay"},
+		Approve:   true,
+	}
+
+	stdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	out.Render(result)
+	require.NoError(t, w.Close())
+	os.Stdout = stdout
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	assert.Contains(t, buf.String(), "Low issue a.go")
+}
+
+func TestRenderVibeCheckMultipleFlagsCommaBranch(t *testing.T) {
+	out := NewTerminalOutput()
+	stdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	out.renderVibeCheck(model.VibeCheck{Score: 6, Verdict: "Okay", Flags: []string{"a", "b"}})
+
+	require.NoError(t, w.Close())
+	os.Stdout = stdout
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	assert.Contains(t, buf.String(), "`a`, `b`")
+}

--- a/internal/review/orchestrator.go
+++ b/internal/review/orchestrator.go
@@ -47,6 +47,10 @@ type contextWarning struct {
 	err  error
 }
 
+var enrichContext = func(o *Orchestrator, ctx context.Context, owner, repo string, pr *model.PR, prCtx *PRContext, depth ContextDepth) ([]contextWarning, error) {
+	return o.enrichPRContext(ctx, owner, repo, pr, prCtx, depth)
+}
+
 // NewOrchestrator creates a new review orchestrator.
 func NewOrchestrator(aiClient ai.AIClient, ghClient github.PRClient, cfg *config.Config) *Orchestrator {
 	return &Orchestrator{
@@ -91,7 +95,7 @@ func (o *Orchestrator) Review(ctx context.Context, owner, repo string, prNumber 
 	if depth == "" {
 		depth = ContextDepthDiffOnly
 	}
-	contextWarnings, err := o.enrichPRContext(ctx, owner, repo, pr, prCtx, depth)
+	contextWarnings, err := enrichContext(o, ctx, owner, repo, pr, prCtx, depth)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load PR context: %w", err)
 	}

--- a/internal/review/orchestrator_test.go
+++ b/internal/review/orchestrator_test.go
@@ -8,12 +8,31 @@ import (
 	"os"
 	"testing"
 
+	"github.com/AtomicWasTaken/surge/internal/ai"
 	"github.com/AtomicWasTaken/surge/internal/config"
 	"github.com/AtomicWasTaken/surge/internal/model"
 	"github.com/AtomicWasTaken/surge/internal/output"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type stubAIClient struct {
+	response *ai.CompletionResponse
+	err      error
+	req      *ai.CompletionRequest
+}
+
+func (s *stubAIClient) Complete(ctx context.Context, req *ai.CompletionRequest) (*ai.CompletionResponse, error) {
+	s.req = req
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.response, nil
+}
+
+func (s *stubAIClient) Name() string {
+	return "stub"
+}
 
 type stubPRClient struct {
 	comments                []*model.PRComment
@@ -36,10 +55,25 @@ type stubPRClient struct {
 	deleteReviewCommentErrs map[int64]error
 	deleteReviewErrs        map[int64]error
 	dismissReviewErrs       map[int64]error
+	pr                      *model.PR
+	prErr                   error
+	files                   []model.FileChange
+	filesErr                error
+	labels                  []string
+	listLabelsErr           error
+	addLabelsCalls          [][]string
+	removeLabelCalls        []string
+	upsertedLabels          []labelSpec
+	addLabelsErr            error
+	removeLabelErr          error
+	upsertLabelErr          error
 }
 
 func (s *stubPRClient) GetPR(ctx context.Context, owner, repo string, prNumber int) (*model.PR, error) {
-	return nil, nil
+	if s.prErr != nil {
+		return nil, s.prErr
+	}
+	return s.pr, nil
 }
 
 func (s *stubPRClient) GetDiff(ctx context.Context, owner, repo string, prNumber int) (string, error) {
@@ -47,7 +81,10 @@ func (s *stubPRClient) GetDiff(ctx context.Context, owner, repo string, prNumber
 }
 
 func (s *stubPRClient) GetFiles(ctx context.Context, owner, repo string, prNumber int) ([]model.FileChange, error) {
-	return nil, nil
+	if s.filesErr != nil {
+		return nil, s.filesErr
+	}
+	return s.files, nil
 }
 
 func (s *stubPRClient) GetFileContent(ctx context.Context, owner, repo, path, ref string) (string, error) {
@@ -124,19 +161,453 @@ func (s *stubPRClient) DeleteReviewComment(ctx context.Context, owner, repo stri
 }
 
 func (s *stubPRClient) ListLabels(ctx context.Context, owner, repo string, prNumber int) ([]string, error) {
-	return nil, nil
+	if s.listLabelsErr != nil {
+		return nil, s.listLabelsErr
+	}
+	return s.labels, nil
 }
 
 func (s *stubPRClient) AddLabels(ctx context.Context, owner, repo string, prNumber int, labels []string) error {
+	if s.addLabelsErr != nil {
+		return s.addLabelsErr
+	}
+	s.addLabelsCalls = append(s.addLabelsCalls, append([]string(nil), labels...))
 	return nil
 }
 
 func (s *stubPRClient) RemoveLabel(ctx context.Context, owner, repo string, prNumber int, label string) error {
+	if s.removeLabelErr != nil {
+		return s.removeLabelErr
+	}
+	s.removeLabelCalls = append(s.removeLabelCalls, label)
 	return nil
 }
 
 func (s *stubPRClient) UpsertLabel(ctx context.Context, owner, repo, name, color, description string) error {
+	if s.upsertLabelErr != nil {
+		return s.upsertLabelErr
+	}
+	s.upsertedLabels = append(s.upsertedLabels, labelSpec{Name: name, Color: color, Description: description})
 	return nil
+}
+
+func TestReviewEndToEndDryRun(t *testing.T) {
+	aiClient := &stubAIClient{
+		response: &ai.CompletionResponse{
+			Content:   `{"summary":"Looks good overall.","filesOverview":[{"path":"a.go","changes":"change","risk":"low"}],"findings":[{"severity":"medium","category":"logic","file":"a.go","line":2,"title":"Handle edge case","body":"A branch is missing."}],"vibeCheck":{"score":10,"verdict":"Perfect","flags":[]},"recommendations":["Add a regression test"],"approve":false}`,
+			TokensIn:  12,
+			TokensOut: 34,
+		},
+	}
+	ghClient := &stubPRClient{
+		pr: &model.PR{Title: "PR title", Body: "PR body", ChangedFiles: 1, HeadSHA: "abc123"},
+		files: []model.FileChange{
+			{Path: "a.go", Status: model.FileStatusModified, Additions: 1, Deletions: 0, Patch: "@@ -1,2 +1,2 @@\n line1\n+line2"},
+		},
+	}
+	cfg := &config.Config{
+		AI:                config.AIConfig{Model: "test-model"},
+		ContextDepth:      string(ContextDepthFull),
+		Output:            config.OutputConfig{Format: "json"},
+		Categories:        config.CategoriesConfig{Security: true, Performance: true, Logic: true, Maintainability: true, Vibe: true},
+		CommentMarker:     "SURGE",
+		MaxTokens:         99,
+		Temperature:       0.4,
+		EnablePRLabels:    true,
+		PRLabelPrefix:     "surge",
+		MaxInlineComments: 10,
+		Verbose:           true,
+	}
+	ghClient.fileContents = map[string]string{"a.go@abc123": "package main\n"}
+	o := NewOrchestrator(aiClient, ghClient, cfg)
+
+	stdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	result, err := o.Review(context.Background(), "octo", "surge", 1, true)
+
+	require.NoError(t, w.Close())
+	os.Stdout = stdout
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, aiClient.req)
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+
+	assert.Equal(t, "test-model", aiClient.req.Model)
+	assert.Contains(t, aiClient.req.Messages[0].Content, "Full file content")
+	assert.Contains(t, buf.String(), `"summary": "Looks good overall."`)
+	assert.Equal(t, 1, result.Stats.FilesReviewed)
+	assert.Equal(t, 12, result.Stats.TokensIn)
+	assert.Contains(t, result.VibeCheck.Flags, "ai_fluff")
+	assert.Equal(t, "Excellent. Hand-crafted, idiomatic code.", result.VibeCheck.Verdict)
+}
+
+func TestReviewEndToEndPostAndTerminal(t *testing.T) {
+	aiClient := &stubAIClient{
+		response: &ai.CompletionResponse{
+			Content:   `{"summary":"Plain summary.","findings":[{"severity":"high","category":"logic","file":"a.go","line":2,"title":"Issue","body":"Fix it"}],"vibeCheck":{"score":6,"verdict":"ok","flags":[]},"recommendations":["Ship it"],"approve":true}`,
+			TokensIn:  5,
+			TokensOut: 7,
+		},
+	}
+	ghClient := &stubPRClient{
+		pr:             &model.PR{Title: "PR title", HeadSHA: "abc123"},
+		files:          []model.FileChange{{Path: "a.go", Status: model.FileStatusModified, Patch: "@@ -1,2 +1,2 @@\n line1\n+line2"}},
+		reviewComments: map[int64][]*model.PRReviewComment{},
+	}
+	cfg := &config.Config{
+		AI:             config.AIConfig{Model: "test-model"},
+		Output:         config.OutputConfig{Format: "terminal"},
+		Categories:     config.CategoriesConfig{Security: true, Performance: true, Logic: true, Maintainability: true, Vibe: true},
+		CommentMarker:  "SURGE",
+		EnablePRLabels: false,
+		ContextDepth:   string(ContextDepthDiffOnly),
+	}
+	o := NewOrchestrator(aiClient, ghClient, cfg)
+
+	stdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	result, err := o.Review(context.Background(), "octo", "surge", 1, false)
+
+	require.NoError(t, w.Close())
+	os.Stdout = stdout
+	require.NoError(t, err)
+	assert.True(t, result.Approve)
+	require.Len(t, ghClient.postedCommentBodies, 1)
+	require.Len(t, ghClient.postedReviews, 1)
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	require.NoError(t, r.Close())
+	assert.Contains(t, buf.String(), "Vibe Check")
+}
+
+func TestReviewErrors(t *testing.T) {
+	cfg := &config.Config{
+		AI:            config.AIConfig{Model: "test-model"},
+		ContextDepth:  string(ContextDepthDiffOnly),
+		Output:        config.OutputConfig{Format: "terminal"},
+		Categories:    config.CategoriesConfig{Security: true},
+		CommentMarker: "SURGE",
+	}
+
+	t.Run("pr fetch", func(t *testing.T) {
+		o := NewOrchestrator(&stubAIClient{}, &stubPRClient{prErr: errors.New("boom")}, cfg)
+		_, err := o.Review(context.Background(), "octo", "surge", 1, true)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed to fetch PR")
+	})
+
+	t.Run("files fetch", func(t *testing.T) {
+		o := NewOrchestrator(&stubAIClient{}, &stubPRClient{pr: &model.PR{}, filesErr: errors.New("boom")}, cfg)
+		_, err := o.Review(context.Background(), "octo", "surge", 1, true)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed to fetch files")
+	})
+
+	t.Run("ai failure", func(t *testing.T) {
+		o := NewOrchestrator(&stubAIClient{err: errors.New("boom")}, &stubPRClient{pr: &model.PR{}, files: nil}, cfg)
+		_, err := o.Review(context.Background(), "octo", "surge", 1, true)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "AI request failed")
+	})
+
+	t.Run("parse failure", func(t *testing.T) {
+		o := NewOrchestrator(&stubAIClient{response: &ai.CompletionResponse{Content: `not json`}}, &stubPRClient{pr: &model.PR{}, files: nil}, cfg)
+		_, err := o.Review(context.Background(), "octo", "surge", 1, true)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed to parse AI response")
+	})
+
+	t.Run("post review failure", func(t *testing.T) {
+		client := &stubPRClientWithPostError{
+			stubPRClient: stubPRClient{
+				pr:    &model.PR{},
+				files: []model.FileChange{},
+			},
+			postCommentErr: errors.New("boom"),
+		}
+		o := NewOrchestrator(&stubAIClient{response: &ai.CompletionResponse{
+			Content: `{"summary":"ok","vibeCheck":{"score":5,"verdict":"ok","flags":[]},"recommendations":[],"approve":true}`,
+		}}, client, cfg)
+		_, err := o.Review(context.Background(), "octo", "surge", 1, false)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "failed to post review")
+	})
+}
+
+func TestBuildPRContextAndHelpers(t *testing.T) {
+	o := NewOrchestrator(nil, &stubPRClient{}, &config.Config{CommentMarker: "SURGE"})
+	prCtx := o.buildPRContext(&model.PR{Title: "Title", Body: "Body"}, []model.FileChange{
+		{Path: "a.go", Status: model.FileStatusAdded, Additions: 2, Deletions: 0, Patch: "@@"},
+	})
+
+	assert.Equal(t, "Title", prCtx.Title)
+	assert.Len(t, prCtx.Files, 1)
+	assert.Equal(t, "a.go", prCtx.Files[0].Path)
+	assert.True(t, supportsFileContent(string(model.FileStatusModified)))
+	assert.False(t, supportsFileContent(string(model.FileStatusDeleted)))
+}
+
+func TestSyncPRLabelsAndHelpers(t *testing.T) {
+	client := &stubPRClient{
+		labels: []string{"Surge: Reviewed", "Surge: Decision / Changes Requested", "other"},
+	}
+	o := NewOrchestrator(nil, client, &config.Config{
+		CommentMarker:  "SURGE",
+		EnablePRLabels: true,
+		PRLabelPrefix:  "surge",
+	})
+	result := &model.ReviewResult{
+		Approve: true,
+		Findings: []model.Finding{
+			{Severity: model.SeverityHigh},
+			{Severity: model.SeverityMedium},
+		},
+		Stats: model.ReviewStats{FilesReviewed: 9},
+	}
+
+	err := o.syncPRLabels(context.Background(), "octo", "surge", 1, result)
+	require.NoError(t, err)
+	require.Len(t, client.upsertedLabels, 4)
+	assert.Equal(t, []string{"Surge: Decision / Changes Requested"}, client.removeLabelCalls)
+	require.Len(t, client.addLabelsCalls, 1)
+	assert.Len(t, client.addLabelsCalls[0], 4)
+
+	assert.True(t, isManagedSurgeLabel("surge", "Surge: Reviewed"))
+	assert.False(t, isManagedSurgeLabel("surge", "other"))
+	assert.Equal(t, "high", classifyReviewEffort(&model.ReviewResult{
+		Findings: []model.Finding{{Severity: model.SeverityCritical}},
+	}))
+	assert.Equal(t, "medium", classifyReviewEffort(&model.ReviewResult{
+		Stats: model.ReviewStats{FilesReviewed: 8},
+	}))
+	assert.Equal(t, "low", classifyReviewEffort(&model.ReviewResult{}))
+	assert.Equal(t, "Approved", decisionTitle("approved"))
+	assert.Equal(t, "Changes Requested", decisionTitle("other"))
+	assert.Equal(t, "None", findingsTitle("none found"))
+	assert.Equal(t, "Present", findingsTitle("present"))
+	assert.Equal(t, "", titleWord(""))
+}
+
+func TestSyncPRLabelsErrorsAndEnabledCategories(t *testing.T) {
+	cfg := &config.Config{
+		CommentMarker:  "SURGE",
+		EnablePRLabels: true,
+		PRLabelPrefix:  "",
+		Categories: config.CategoriesConfig{
+			Security: true,
+			Vibe:     true,
+		},
+	}
+	o := NewOrchestrator(nil, &stubPRClient{upsertLabelErr: errors.New("boom")}, cfg)
+	err := o.syncPRLabels(context.Background(), "octo", "surge", 1, &model.ReviewResult{})
+	require.Error(t, err)
+	assert.ElementsMatch(t, []model.Category{model.CategorySecurity, model.CategoryVibe}, o.enabledCategories())
+}
+
+func TestSyncPRLabelsListRemoveAndAddErrors(t *testing.T) {
+	result := &model.ReviewResult{}
+
+	t.Run("list labels error", func(t *testing.T) {
+		o := NewOrchestrator(nil, &stubPRClient{listLabelsErr: errors.New("boom")}, &config.Config{
+			CommentMarker: "SURGE", EnablePRLabels: true,
+		})
+		err := o.syncPRLabels(context.Background(), "o", "r", 1, result)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "boom")
+	})
+
+	t.Run("remove label error", func(t *testing.T) {
+		o := NewOrchestrator(nil, &stubPRClient{
+			labels:         []string{"Surge: Findings / Present"},
+			removeLabelErr: errors.New("boom"),
+		}, &config.Config{CommentMarker: "SURGE", EnablePRLabels: true})
+		err := o.syncPRLabels(context.Background(), "o", "r", 1, result)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "boom")
+	})
+
+	t.Run("add labels error", func(t *testing.T) {
+		o := NewOrchestrator(nil, &stubPRClient{
+			addLabelsErr: errors.New("boom"),
+		}, &config.Config{CommentMarker: "SURGE", EnablePRLabels: true})
+		err := o.syncPRLabels(context.Background(), "o", "r", 1, result)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "boom")
+	})
+}
+
+func TestReviewEmptyDepthAndEnrichError(t *testing.T) {
+	prev := enrichContext
+	t.Cleanup(func() { enrichContext = prev })
+
+	aiClient := &stubAIClient{
+		response: &ai.CompletionResponse{
+			Content: `{"summary":"ok","vibeCheck":{"score":5,"verdict":"ok","flags":[]},"recommendations":[],"approve":true}`,
+		},
+	}
+	ghClient := &stubPRClient{
+		pr:    &model.PR{Title: "PR title"},
+		files: []model.FileChange{},
+	}
+	o := NewOrchestrator(aiClient, ghClient, &config.Config{
+		AI:            config.AIConfig{Model: "m"},
+		Output:        config.OutputConfig{Format: "json"},
+		Categories:    config.CategoriesConfig{Security: true},
+		CommentMarker: "SURGE",
+		ContextDepth:  "",
+	})
+
+	_, err := o.Review(context.Background(), "o", "r", 1, true)
+	require.NoError(t, err)
+	assert.Contains(t, aiClient.req.Messages[0].Content, "Diff:")
+
+	enrichContext = func(o *Orchestrator, ctx context.Context, owner, repo string, pr *model.PR, prCtx *PRContext, depth ContextDepth) ([]contextWarning, error) {
+		return nil, errors.New("boom")
+	}
+	_, err = o.Review(context.Background(), "o", "r", 1, true)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to load PR context")
+}
+
+func TestDeleteOldCommentsListReviewCommentsError(t *testing.T) {
+	client := &stubPRClient{
+		reviews:                []*model.PRReview{{ID: 1, Body: "<!-- SURGE_INLINE -->", State: "COMMENTED"}},
+		listReviewCommentsErrs: map[int64]error{1: errors.New("boom")},
+	}
+	o := NewOrchestrator(nil, client, &config.Config{CommentMarker: "SURGE"})
+	stats, err := o.deleteOldComments(context.Background(), "o", "r", 1)
+	require.Error(t, err)
+	assert.Equal(t, 1, stats.failedOperations)
+	assert.ErrorContains(t, err, "list review comments for review 1")
+}
+
+func TestTitleWordInvalidRune(t *testing.T) {
+	assert.Equal(t, string([]byte{0xff}), titleWord(string([]byte{0xff})))
+}
+
+func TestPostReviewBranchesAndErrors(t *testing.T) {
+	t.Run("approve event and label warning", func(t *testing.T) {
+		client := &stubPRClient{
+			reviewComments: map[int64][]*model.PRReviewComment{},
+			listLabelsErr:  errors.New("labels unavailable"),
+		}
+		cfg := &config.Config{
+			CommentMarker:         "SURGE",
+			EnablePRLabels:        true,
+			DisableSummaryComment: true,
+			MaxInlineComments:     1,
+		}
+		o := NewOrchestrator(nil, client, cfg)
+		result := &model.ReviewResult{
+			Approve: true,
+			Findings: []model.Finding{
+				{Severity: model.SeverityHigh, File: "a.go", Line: 2, Title: "Bug", Body: "Fix"},
+				{Severity: model.SeverityHigh, File: "a.go", Line: 2, Title: "Bug2", Body: "Fix"},
+			},
+		}
+		files := []model.FileChange{{Path: "a.go", Patch: "@@ -1,2 +1,2 @@\n line1\n+line2"}}
+
+		stdout := os.Stdout
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		os.Stdout = w
+
+		err = o.postReview(context.Background(), "o", "r", 1, result, files)
+
+		require.NoError(t, w.Close())
+		os.Stdout = stdout
+		require.NoError(t, err)
+		require.Len(t, client.postedReviews, 1)
+		assert.Equal(t, "APPROVE", client.postedReviews[0].Event)
+		assert.Len(t, client.postedReviews[0].Comments, 1)
+
+		var buf bytes.Buffer
+		_, err = io.Copy(&buf, r)
+		require.NoError(t, err)
+		require.NoError(t, r.Close())
+		assert.Contains(t, buf.String(), "Warning: failed to sync PR labels")
+	})
+
+	t.Run("summary post error", func(t *testing.T) {
+		client := &stubPRClientWithPostError{stubPRClient: stubPRClient{}, postCommentErr: errors.New("boom")}
+		o := NewOrchestrator(nil, client, &config.Config{CommentMarker: "SURGE"})
+		err := o.postReview(context.Background(), "o", "r", 1, &model.ReviewResult{}, nil)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "boom")
+	})
+
+	t.Run("review post error", func(t *testing.T) {
+		client := &stubPRClientWithPostError{stubPRClient: stubPRClient{}, postReviewErr: errors.New("boom")}
+		o := NewOrchestrator(nil, client, &config.Config{CommentMarker: "SURGE", DisableSummaryComment: true})
+		err := o.postReview(context.Background(), "o", "r", 1, &model.ReviewResult{
+			Findings: []model.Finding{{Severity: model.SeverityHigh, File: "a.go", Line: 2, Title: "Bug", Body: "Fix"}},
+		}, []model.FileChange{{Path: "a.go", Patch: "@@ -1,2 +1,2 @@\n line1\n+line2"}})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "boom")
+	})
+}
+
+type stubPRClientWithPostError struct {
+	stubPRClient
+	postCommentErr error
+	postReviewErr  error
+}
+
+func (s *stubPRClientWithPostError) PostComment(ctx context.Context, owner, repo string, prNumber int, body string) error {
+	if s.postCommentErr != nil {
+		return s.postCommentErr
+	}
+	return s.stubPRClient.PostComment(ctx, owner, repo, prNumber, body)
+}
+
+func (s *stubPRClientWithPostError) PostReview(ctx context.Context, owner, repo string, prNumber int, review *model.ReviewInput) error {
+	if s.postReviewErr != nil {
+		return s.postReviewErr
+	}
+	return s.stubPRClient.PostReview(ctx, owner, repo, prNumber, review)
+}
+
+func TestBuildInlineCommentsSkipsUnmappableFindings(t *testing.T) {
+	o := NewOrchestrator(nil, &stubPRClient{}, &config.Config{CommentMarker: "SURGE"})
+	comments := o.buildInlineComments(&model.ReviewResult{
+		Findings: []model.Finding{
+			{Severity: model.SeverityHigh, File: "", Line: 2, Title: "skip", Body: "skip"},
+			{Severity: model.SeverityHigh, File: "a.go", Line: 0, Title: "skip", Body: "skip"},
+			{Severity: model.SeverityHigh, File: "a.go", Line: 9, Title: "skip", Body: "skip"},
+		},
+	}, []model.FileChange{{Path: "a.go", Patch: "@@ -1,2 +1,2 @@\n line1\n+line2"}})
+	assert.Empty(t, comments)
+}
+
+func TestDeleteOldCommentsListFailures(t *testing.T) {
+	client := &stubPRClient{
+		listCommentsErr: errors.New("boom comments"),
+		listReviewsErr:  errors.New("boom reviews"),
+	}
+	o := NewOrchestrator(nil, client, &config.Config{CommentMarker: "SURGE"})
+	stats, err := o.deleteOldComments(context.Background(), "o", "r", 1)
+	require.Error(t, err)
+	assert.Equal(t, 2, stats.failedOperations)
+	assert.ErrorContains(t, err, "list issue comments")
+	assert.ErrorContains(t, err, "list reviews")
+}
+
+func TestFindPositionInPatchBranches(t *testing.T) {
+	assert.Equal(t, 0, findPositionInPatch("", 1))
+	assert.Equal(t, 3, findPositionInPatch("@@ -1,2 +1,2 @@\n line1\n+line2", 2))
+	assert.Equal(t, 0, findPositionInPatch("@@ -1,2 +1,2 @@\n-line1\n line2", 1))
 }
 
 func TestDeleteOldCommentsCleansIssueCommentsAndSupersedesReviews(t *testing.T) {
@@ -227,6 +698,21 @@ func TestDeleteOldCommentsSkipsUnknownAndEmptyStates(t *testing.T) {
 		dismissedReviews: 1,
 		skippedReviews:   2,
 	}, stats)
+}
+
+func TestDeleteOldCommentsSkipsDismissedReviews(t *testing.T) {
+	client := &stubPRClient{
+		reviews: []*model.PRReview{
+			{ID: 40, Body: "<!-- SURGE_INLINE -->", State: "DISMISSED"},
+		},
+		reviewComments: map[int64][]*model.PRReviewComment{
+			40: {},
+		},
+	}
+	o := NewOrchestrator(nil, client, &config.Config{CommentMarker: "SURGE"})
+	stats, err := o.deleteOldComments(context.Background(), "o", "r", 1)
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.skippedReviews)
 }
 
 func TestDeleteOldCommentsContinuesAfterCleanupFailures(t *testing.T) {

--- a/internal/review/output_test.go
+++ b/internal/review/output_test.go
@@ -1,0 +1,42 @@
+package review
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOutputParserParseVariants(t *testing.T) {
+	parser := NewOutputParser()
+
+	result, err := parser.Parse(`{"summary":"ok","vibeCheck":{"score":5,"verdict":"ok","flags":[]},"recommendations":[],"approve":true}`)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", result.Summary)
+
+	result, err = parser.Parse("```json\n{\"summary\":\"wrapped\",\"vibeCheck\":{\"score\":5,\"verdict\":\"ok\",\"flags\":[]},\"recommendations\":[],\"approve\":true}\n```")
+	require.NoError(t, err)
+	assert.Equal(t, "wrapped", result.Summary)
+
+	result, err = parser.Parse("prefix {\"summary\":\"embedded\",\"vibeCheck\":{\"score\":5,\"verdict\":\"ok\",\"flags\":[]},\"recommendations\":[],\"approve\":true} suffix")
+	require.NoError(t, err)
+	assert.Equal(t, "embedded", result.Summary)
+
+	_, err = parser.Parse("not json")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to parse AI response as JSON")
+}
+
+func TestParseJSONAndHelpers(t *testing.T) {
+	parser := NewOutputParser()
+
+	_, err := parser.parseJSON(`{"vibeCheck":{"score":5,"verdict":"ok","flags":[]},"recommendations":[],"approve":true}`)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "missing required field: summary")
+
+	assert.Equal(t, `{"a":1}`, stripCodeFences("```json\n{\"a\":1}\n```"))
+	assert.Equal(t, `{"a":1}`, stripCodeFences("```\n{\"a\":1}\n```"))
+	assert.Equal(t, "", extractJSON("no braces"))
+	assert.Equal(t, `{"a":{"b":1}}`, extractJSON("xx {\"a\":{\"b\":1}} yy"))
+	assert.Equal(t, "", extractJSON("{\"a\":1"))
+}

--- a/internal/review/review_test.go
+++ b/internal/review/review_test.go
@@ -101,6 +101,107 @@ func TestVibeDetector_NoDeductionForCleanCode(t *testing.T) {
 	assert.GreaterOrEqual(t, result.VibeCheck.Score, 8)
 }
 
+func TestVibeDetectorVerdictBuckets(t *testing.T) {
+	d := NewVibeDetector()
+
+	result := &model.ReviewResult{
+		Summary: "Looks good.",
+		VibeCheck: model.VibeCheck{
+			Score: 10,
+		},
+		Findings: []model.Finding{
+			{Category: model.CategoryVibe, Title: "over-engineered abstraction"},
+			{Category: model.CategoryVibe, Title: "over-engineered factory"},
+			{Category: model.CategoryVibe, Title: "over-engineered wrapper"},
+			{Category: model.CategoryVibe, Title: "over-engineered layer"},
+		},
+	}
+	d.Detect(result, "")
+	assert.Equal(t, "Mixed. Some AI fingerprints detected.", result.VibeCheck.Verdict)
+
+	result = &model.ReviewResult{
+		Summary: "Looks good.",
+		VibeCheck: model.VibeCheck{
+			Score: 6,
+		},
+		Findings: []model.Finding{
+			{Category: model.CategoryVibe, Title: "over-engineered abstraction"},
+			{Category: model.CategoryVibe, Title: "over-engineered factory"},
+		},
+	}
+	d.Detect(result, "")
+	assert.Equal(t, "Concerning. Significant over-engineering or context issues.", result.VibeCheck.Verdict)
+
+	result = &model.ReviewResult{
+		Summary: "Looks good.",
+		VibeCheck: model.VibeCheck{
+			Score: 3,
+		},
+		Findings: []model.Finding{
+			{Category: model.CategoryVibe, Title: "over-engineered abstraction"},
+		},
+	}
+	d.Detect(result, "")
+	assert.Equal(t, "Concerning. Significant over-engineering or context issues.", result.VibeCheck.Verdict)
+}
+
+func TestVibeDetectorSuspiciouslyPerfectAndDedupes(t *testing.T) {
+	d := NewVibeDetector()
+	result := &model.ReviewResult{
+		Summary: "Focused summary.",
+		VibeCheck: model.VibeCheck{
+			Score: 10,
+		},
+		Findings: []model.Finding{
+			{Category: model.CategoryLogic, Title: "a"},
+			{Category: model.CategoryLogic, Title: "b"},
+			{Category: model.CategoryLogic, Title: "c"},
+			{Category: model.CategoryLogic, Title: "d"},
+			{Category: model.CategoryLogic, Title: "e"},
+			{Category: model.CategoryLogic, Title: "f"},
+		},
+	}
+	d.Detect(result, "")
+	assert.Equal(t, 8, result.VibeCheck.Score)
+	assert.Equal(t, []string{"suspiciously_perfect"}, result.VibeCheck.Flags)
+
+	result = &model.ReviewResult{
+		Summary: "Looks good.",
+		VibeCheck: model.VibeCheck{
+			Score: 9,
+			Flags: []string{"existing", "existing"},
+		},
+	}
+	d.Detect(result, "")
+	assert.Equal(t, []string{"existing", "ai_fluff"}, result.VibeCheck.Flags)
+}
+
+func TestVibeDetectorScoreClamps(t *testing.T) {
+	d := NewVibeDetector()
+
+	result := &model.ReviewResult{
+		Summary: "Looks good.",
+		VibeCheck: model.VibeCheck{
+			Score: 1,
+		},
+		Findings: []model.Finding{
+			{Category: model.CategoryVibe, Title: "over-engineered abstraction"},
+			{Category: model.CategoryVibe, Title: "over-engineered factory"},
+		},
+	}
+	d.Detect(result, "")
+	assert.Equal(t, 1, result.VibeCheck.Score)
+
+	result = &model.ReviewResult{
+		Summary: "Focused summary.",
+		VibeCheck: model.VibeCheck{
+			Score: 11,
+		},
+	}
+	d.Detect(result, "")
+	assert.Equal(t, 10, result.VibeCheck.Score)
+}
+
 func TestPromptBuilder_SystemPrompt(t *testing.T) {
 	pb := NewPromptBuilder()
 	prompt := pb.SystemPrompt()

--- a/pkg/httpclient/client_test.go
+++ b/pkg/httpclient/client_test.go
@@ -1,0 +1,160 @@
+package httpclient
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientRequestMethodsAndConfiguration(t *testing.T) {
+	type capturedRequest struct {
+		Method      string
+		Path        string
+		AuthHeader  string
+		UserAgent   string
+		ContentType string
+		Body        map[string]string
+	}
+
+	var requests []capturedRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := map[string]string{}
+		if r.Body != nil {
+			data, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			if len(data) > 0 {
+				require.NoError(t, json.Unmarshal(data, &body))
+			}
+		}
+
+		requests = append(requests, capturedRequest{
+			Method:      r.Method,
+			Path:        r.URL.Path,
+			AuthHeader:  r.Header.Get("Authorization"),
+			UserAgent:   r.Header.Get("User-Agent"),
+			ContentType: r.Header.Get("Content-Type"),
+			Body:        body,
+		})
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`ok`))
+	}))
+	defer server.Close()
+
+	client := New().WithAuth("secret-token")
+	client.SetUserAgent("surge-test")
+	client.SetTimeout(5 * time.Second)
+
+	_, err := client.Get(server.URL + "/get")
+	require.NoError(t, err)
+
+	_, err = client.Post(server.URL+"/post", map[string]string{"hello": "world"})
+	require.NoError(t, err)
+
+	_, err = client.Patch(server.URL+"/patch", map[string]string{"status": "updated"})
+	require.NoError(t, err)
+
+	_, err = client.Delete(server.URL + "/delete")
+	require.NoError(t, err)
+
+	require.Len(t, requests, 4)
+	assert.Equal(t, "Bearer secret-token", requests[0].AuthHeader)
+	assert.Equal(t, "surge-test", requests[0].UserAgent)
+	assert.Equal(t, http.MethodGet, requests[0].Method)
+	assert.Equal(t, "/get", requests[0].Path)
+	assert.Empty(t, requests[0].ContentType)
+
+	assert.Equal(t, http.MethodPost, requests[1].Method)
+	assert.Equal(t, "application/json", requests[1].ContentType)
+	assert.Equal(t, map[string]string{"hello": "world"}, requests[1].Body)
+
+	assert.Equal(t, http.MethodPatch, requests[2].Method)
+	assert.Equal(t, "application/json", requests[2].ContentType)
+	assert.Equal(t, map[string]string{"status": "updated"}, requests[2].Body)
+
+	assert.Equal(t, http.MethodDelete, requests[3].Method)
+	assert.Equal(t, "/delete", requests[3].Path)
+
+	assert.Equal(t, 5*time.Second, client.HTTPClient().Timeout)
+	assert.Same(t, client.HTTPClient(), client.BaseClient().GetClient())
+}
+
+func TestClientWithoutAuthDoesNotSetAuthorizationHeader(t *testing.T) {
+	var authHeader string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := New()
+	_, err := client.Get(server.URL)
+	require.NoError(t, err)
+
+	assert.Empty(t, authHeader)
+}
+
+func TestClientRetriesOnServerErrorsAndRateLimits(t *testing.T) {
+	t.Run("retries on 500", func(t *testing.T) {
+		var hits int
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hits++
+			if hits < 2 {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		client := New()
+		_, err := client.Get(server.URL)
+		require.NoError(t, err)
+		assert.Equal(t, 2, hits)
+	})
+
+	t.Run("retries on 429", func(t *testing.T) {
+		var hits int
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hits++
+			if hits < 2 {
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		client := New()
+		_, err := client.Get(server.URL)
+		require.NoError(t, err)
+		assert.Equal(t, 2, hits)
+	})
+}
+
+func TestClientRetryConditionBranches(t *testing.T) {
+	client := New()
+	require.NotEmpty(t, client.BaseClient().RetryConditions)
+	condition := client.BaseClient().RetryConditions[0]
+
+	assert.True(t, condition(nil, errors.New("network down")))
+
+	resp429 := &resty.Response{RawResponse: &http.Response{StatusCode: http.StatusTooManyRequests}}
+	assert.True(t, condition(resp429, nil))
+
+	resp500 := &resty.Response{RawResponse: &http.Response{StatusCode: http.StatusInternalServerError}}
+	assert.True(t, condition(resp500, nil))
+
+	resp200 := &resty.Response{RawResponse: &http.Response{StatusCode: http.StatusOK}}
+	assert.False(t, condition(resp200, nil))
+}


### PR DESCRIPTION
## Summary
- drive the repository to 100% Go statement coverage
- add focused tests plus small testability refactors where unreachable branches needed injection
- add README badges for Go version, test status, and 100% coverage

## Verification
- go test ./...
- go test ./... -coverprofile=/tmp/surge-cover-18.out
- go tool cover -func=/tmp/surge-cover-18.out

## Coverage
All covered packages now report 100.0% statement coverage.
